### PR TITLE
chore: sync version to 1.4.0 on dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocinante",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "description": "A real-time dashboard for monitoring and interacting with GitHub Copilot CLI sessions. Named after the ship from The Expanse, which was named after Don Quixote's horse — a workhorse.",
   "author": "gaburn",
   "license": "MIT",


### PR DESCRIPTION
Syncs the package.json version to 1.4.0 on the dev branch so the Settings pane displays the correct release version.