### PR TITLE
fix: session detail 404 + fresh-user welcome experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocinante",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocinante",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -20,6 +20,7 @@
         "d3-force": "^3.0.0",
         "dotenv": "^17.4.0",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.3.2",
         "js-yaml": "^4.1.1",
         "node-pty": "^1.1.0",
         "react": "^19.2.4",
@@ -3402,6 +3403,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3843,6 +3862,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "node-pty": "^1.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/server/routes/__tests__/sessionsStatus.test.ts
+++ b/server/routes/__tests__/sessionsStatus.test.ts
@@ -107,7 +107,9 @@ function callGetSessionsStatus(): { statusCode: number; body: unknown } {
     throw new Error('GET /sessions/status route not found on router');
   }
 
-  layer.route.stack[0].handle(req, res, () => {});
+  // Call the actual route handler, not the rate-limiter middleware at [0]
+  const handlers = layer.route.stack;
+  handlers[handlers.length - 1].handle(req, res, () => {});
   return res;
 }
 

--- a/server/routes/__tests__/sessionsStatus.test.ts
+++ b/server/routes/__tests__/sessionsStatus.test.ts
@@ -107,7 +107,9 @@ function callGetSessionsStatus(): { statusCode: number; body: unknown } {
     throw new Error('GET /sessions/status route not found on router');
   }
 
-  layer.route.stack[0].handle(req, res, () => {});
+  // Call the last handler in the stack (skips middleware like rate limiters)
+  const handlers = layer.route.stack;
+  handlers[handlers.length - 1].handle(req, res, () => {});
   return res;
 }
 

--- a/server/routes/__tests__/sessionsStatus.test.ts
+++ b/server/routes/__tests__/sessionsStatus.test.ts
@@ -107,9 +107,7 @@ function callGetSessionsStatus(): { statusCode: number; body: unknown } {
     throw new Error('GET /sessions/status route not found on router');
   }
 
-  // Call the actual route handler, not the rate-limiter middleware at [0]
-  const handlers = layer.route.stack;
-  handlers[handlers.length - 1].handle(req, res, () => {});
+  layer.route.stack[0].handle(req, res, () => {});
   return res;
 }
 

--- a/server/routes/__tests__/sessionsStatus.test.ts
+++ b/server/routes/__tests__/sessionsStatus.test.ts
@@ -97,7 +97,7 @@ function callGetSessionsStatus(): { statusCode: number; body: unknown } {
     body: null as unknown,
     status(code: number) { res.statusCode = code; return res; },
     json(data: unknown) { res.body = data; return res; },
-    set(_k: string, _v: string) { return res; },
+    set() { return res; },
   };
 
   const layer = (sessionsRouter as unknown as { stack: RouteLayer[] }).stack

--- a/server/routes/__tests__/sessionsStatus.test.ts
+++ b/server/routes/__tests__/sessionsStatus.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for GET /api/sessions/status endpoint.
+ *
+ * Returns source-availability metadata for both Copilot and Claude providers.
+ * Always returns 200 — this is a lightweight diagnostic endpoint.
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const { mockExistsSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: { ...actual, existsSync: mockExistsSync },
+    existsSync: mockExistsSync,
+  };
+});
+
+const MOCK_SQLITE = '/mock/session-store.db';
+const MOCK_STATE_DIR = '/mock/session-state';
+const MOCK_CLAUDE_DIR = '/mock/.claude';
+
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    sqliteDbPath: MOCK_SQLITE,
+    sessionStateDir: MOCK_STATE_DIR,
+    claudeDir: MOCK_CLAUDE_DIR,
+    cacheTtlMs: 10000,
+    staleThresholdMs: 300000,
+  })),
+  isAdoConfigured: vi.fn(() => false),
+}));
+
+const mockMapAllSessionSummaries = vi.fn();
+const mockMapSessionById = vi.fn();
+
+vi.mock('../../services/sessionMapper.js', () => ({
+  mapAllSessionSummaries: (...args: unknown[]) => mockMapAllSessionSummaries(...args),
+  mapSessionById: (...args: unknown[]) => mockMapSessionById(...args),
+}));
+
+vi.mock('../../services/planReader.js', () => ({
+  readSessionPlan: vi.fn(),
+}));
+
+vi.mock('../../services/demoData.js', () => ({
+  generateDemoSessions: vi.fn(() => []),
+  getDemoWorkstreams: vi.fn(() => []),
+}));
+
+vi.mock('../../services/sqliteReader.js', () => ({
+  searchConversations: vi.fn(() => []),
+}));
+
+vi.mock('../../services/archiveStore.js', () => ({
+  getArchivedIds: vi.fn(() => []),
+  setArchivedIds: vi.fn(),
+  addArchived: vi.fn(),
+  removeArchived: vi.fn(),
+  isArchived: vi.fn(() => false),
+  isInitialized: vi.fn(() => false),
+}));
+
+vi.mock('../../services/adoMcpClient.js', () => ({
+  mcpListPullRequests: vi.fn(),
+  mcpGetPullRequest: vi.fn(),
+}));
+
+vi.mock('../../services/adoClient.js', () => ({
+  getPullRequestsByBranches: vi.fn(),
+  getWorkItemsForPullRequest: vi.fn(),
+}));
+
+import sessionsRouter from '../sessions.js';
+import type { SourceStatus } from '../../services/providers/types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+type RouteLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: (...args: unknown[]) => unknown }>;
+  };
+};
+
+function callGetSessionsStatus(): { statusCode: number; body: unknown } {
+  const req = { method: 'GET', url: '/sessions/status', params: {}, query: {} } as never;
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) { res.statusCode = code; return res; },
+    json(data: unknown) { res.body = data; return res; },
+    set(_k: string, _v: string) { return res; },
+  };
+
+  const layer = (sessionsRouter as unknown as { stack: RouteLayer[] }).stack
+    .find((l) => l.route?.path === '/sessions/status' && l.route?.methods?.get);
+
+  if (!layer?.route) {
+    throw new Error('GET /sessions/status route not found on router');
+  }
+
+  layer.route.stack[0].handle(req, res, () => {});
+  return res;
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExistsSync.mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('GET /api/sessions/status', () => {
+  describe('response shape', () => {
+    it('returns correct shape with copilot and claude source info', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const { statusCode, body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(statusCode).toBe(200);
+      expect(status).toHaveProperty('copilot');
+      expect(status).toHaveProperty('claude');
+      expect(status.copilot).toHaveProperty('available');
+      expect(status.copilot).toHaveProperty('sqliteAvailable');
+      expect(status.copilot).toHaveProperty('filesystemAvailable');
+      expect(status.copilot).toHaveProperty('sessionStateDir');
+      expect(status.claude).toHaveProperty('available');
+      expect(status.claude).toHaveProperty('claudeDir');
+    });
+  });
+
+  describe('copilot availability', () => {
+    it('reports copilot available when SQLite exists', () => {
+      mockExistsSync.mockImplementation((p: string) => p === MOCK_SQLITE);
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.copilot.available).toBe(true);
+      expect(status.copilot.sqliteAvailable).toBe(true);
+      expect(status.copilot.filesystemAvailable).toBe(false);
+    });
+
+    it('reports copilot available when sessionStateDir exists (no SQLite)', () => {
+      mockExistsSync.mockImplementation((p: string) => p === MOCK_STATE_DIR);
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.copilot.available).toBe(true);
+      expect(status.copilot.sqliteAvailable).toBe(false);
+      expect(status.copilot.filesystemAvailable).toBe(true);
+    });
+
+    it('reports copilot available when both SQLite and filesystem exist', () => {
+      mockExistsSync.mockImplementation((p: string) =>
+        p === MOCK_SQLITE || p === MOCK_STATE_DIR,
+      );
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.copilot.available).toBe(true);
+      expect(status.copilot.sqliteAvailable).toBe(true);
+      expect(status.copilot.filesystemAvailable).toBe(true);
+    });
+  });
+
+  describe('claude availability', () => {
+    it('reports claude available when claudeDir exists', () => {
+      mockExistsSync.mockImplementation((p: string) => p === MOCK_CLAUDE_DIR);
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.claude.available).toBe(true);
+    });
+
+    it('reports claude unavailable when claudeDir does not exist', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.claude.available).toBe(false);
+    });
+  });
+
+  describe('both unavailable', () => {
+    it('reports everything unavailable when nothing exists on disk', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.copilot.available).toBe(false);
+      expect(status.copilot.sqliteAvailable).toBe(false);
+      expect(status.copilot.filesystemAvailable).toBe(false);
+      expect(status.claude.available).toBe(false);
+    });
+  });
+
+  describe('reliability', () => {
+    it('always returns 200 (never errors for a status check)', () => {
+      // Even with everything missing, status code is 200
+      mockExistsSync.mockReturnValue(false);
+      const { statusCode } = callGetSessionsStatus();
+      expect(statusCode).toBe(200);
+    });
+
+    it('includes sessionStateDir and claudeDir paths in the response', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const { body } = callGetSessionsStatus();
+      const status = body as SourceStatus;
+
+      expect(status.copilot.sessionStateDir).toBe(MOCK_STATE_DIR);
+      expect(status.claude.claudeDir).toBe(MOCK_CLAUDE_DIR);
+    });
+  });
+});

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import * as fs from 'node:fs';
 import { mapAllSessionSummaries, mapSessionById } from '../services/sessionMapper.js';
 import { readSessionPlan } from '../services/planReader.js';
 import { generateDemoSessions, getDemoWorkstreams } from '../services/demoData.js';
@@ -13,10 +14,9 @@ import {
   isInitialized as isArchiveInitialized,
 } from '../services/archiveStore.js';
 import type { SessionSummary } from '../../src/types/index.js';
+import type { SourceStatus } from '../services/providers/types.js';
 
 const sessionsRouter = Router();
-
-/* ── Response cache for GET /api/sessions ─────────────────────── */
 let responseCache: { data: SessionSummary[]; expires: number; includeArchived: boolean } | null = null;
 
 /** Invalidate the response cache (e.g., after a write-path event). */
@@ -24,7 +24,7 @@ export function invalidateSessionsCache(): void {
   responseCache = null;
 }
 
-sessionsRouter.get('/sessions', (req, res) => {
+sessionsRouter.get('/sessions', async (req, res) => {
   try {
     if (process.env.DEMO_MODE === 'true') {
       const sessions = generateDemoSessions();
@@ -47,6 +47,12 @@ sessionsRouter.get('/sessions', (req, res) => {
       : undefined;
 
     const sessions = mapAllSessionSummaries(excludeIds);
+
+    // ADO enrichment disabled — the MCP SDK dynamic import blocks the Node.js
+    // event loop under tsx watch, and the REST fallback uses execSync which also
+    // blocks. Deliverables are available per-session via the useSessionDeliverables
+    // hook and GET /api/ado/session-deliverables?branch=X endpoint instead.
+    // TODO: Re-enable when running with compiled JS (node dist/) in production.
 
     const { cacheTtlMs } = getConfig();
     responseCache = { data: sessions, expires: now + cacheTtlMs, includeArchived };
@@ -75,6 +81,35 @@ sessionsRouter.get('/sessions/search', (req, res) => {
       isArchived: isArchived(r.sessionId),
     }));
     res.json(annotated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: message });
+  }
+});
+
+/* ── Source status endpoint ────────────────────────────────────── */
+
+sessionsRouter.get('/sessions/status', (_req, res) => {
+  try {
+    const { sqliteDbPath, sessionStateDir, claudeDir } = getConfig();
+
+    const sqliteAvailable = fs.existsSync(sqliteDbPath);
+    const filesystemAvailable = fs.existsSync(sessionStateDir);
+
+    const status: SourceStatus = {
+      copilot: {
+        available: sqliteAvailable || filesystemAvailable,
+        sqliteAvailable,
+        filesystemAvailable,
+        sessionStateDir,
+      },
+      claude: {
+        available: fs.existsSync(claudeDir),
+        claudeDir,
+      },
+    };
+
+    res.json(status);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     res.status(500).json({ error: message });

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import * as fs from 'node:fs';
 import { mapAllSessionSummaries, mapSessionById } from '../services/sessionMapper.js';
 import { readSessionPlan } from '../services/planReader.js';
@@ -17,6 +18,12 @@ import type { SessionSummary } from '../../src/types/index.js';
 import type { SourceStatus } from '../services/providers/types.js';
 
 const sessionsRouter = Router();
+const statusLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // limit each IP to 60 requests per window
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 let responseCache: { data: SessionSummary[]; expires: number; includeArchived: boolean } | null = null;
 
 /** Invalidate the response cache (e.g., after a write-path event). */
@@ -89,7 +96,7 @@ sessionsRouter.get('/sessions/search', (req, res) => {
 
 /* ── Source status endpoint ────────────────────────────────────── */
 
-sessionsRouter.get('/sessions/status', (_req, res) => {
+sessionsRouter.get('/sessions/status', statusLimiter, (_req, res) => {
   try {
     const { sqliteDbPath, sessionStateDir, claudeDir } = getConfig();
 

--- a/server/services/__tests__/eventTailReaderHead.test.ts
+++ b/server/services/__tests__/eventTailReaderHead.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Tests for readEventsHead() — reads the first 64KB of events.jsonl
+ * to extract session metadata (createdAt, firstUserMessage, turnCount).
+ *
+ * Uses a real fixture directory on disk so we exercise the actual file I/O
+ * code paths (stat, read, partial-file truncation) rather than mocking fs.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = path.join(__dirname, '.head-fixtures');
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+const mockGetConfig = vi.fn();
+
+vi.mock('../../config.js', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+}));
+
+vi.mock('../../utils/sanitize.js', () => ({
+  sanitizeSessionId: (id: string) => id,
+}));
+
+import { readEventsHead } from '../eventTailReader.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeEvent(
+  type: string,
+  data: Record<string, unknown>,
+  timestamp: string,
+): string {
+  return JSON.stringify({
+    type,
+    id: `evt-${Math.random().toString(36).slice(2, 9)}`,
+    parentId: null,
+    timestamp,
+    data,
+  });
+}
+
+function createSessionDir(sessionId: string, eventsContent?: string): void {
+  const dir = path.join(FIXTURES_DIR, sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  if (eventsContent !== undefined) {
+    fs.writeFileSync(path.join(dir, 'events.jsonl'), eventsContent, 'utf8');
+  }
+}
+
+// ── Setup / teardown ─────────────────────────────────────────────
+
+beforeAll(() => {
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockReturnValue({
+    sessionStateDir: FIXTURES_DIR,
+    tailBytes: 524288,
+  });
+  // Wipe session dirs from previous tests
+  for (const entry of fs.readdirSync(FIXTURES_DIR)) {
+    fs.rmSync(path.join(FIXTURES_DIR, entry), { recursive: true, force: true });
+  }
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('readEventsHead', () => {
+  describe('happy path', () => {
+    it('returns correct createdAt, firstUserMessage, and turnCount for multiple events', () => {
+      const events = [
+        makeEvent('user.message', { content: 'Hello world' }, '2026-01-01T00:00:00Z'),
+        makeEvent('assistant.message', { content: 'Hi there' }, '2026-01-01T00:00:01Z'),
+        makeEvent('user.message', { content: 'Fix the bug' }, '2026-01-01T00:00:02Z'),
+      ].join('\n');
+      createSessionDir('session-happy', events);
+
+      const result = readEventsHead('session-happy');
+
+      expect(result.createdAt).toBe('2026-01-01T00:00:00Z');
+      expect(result.firstUserMessage).toBe('Hello world');
+      expect(result.turnCount).toBe(2);
+    });
+
+    it('sets createdAt from the first event regardless of type', () => {
+      const events = [
+        makeEvent('assistant.message', { content: 'Starting...' }, '2026-06-15T10:30:00Z'),
+        makeEvent('user.message', { content: 'Thanks' }, '2026-06-15T10:30:05Z'),
+      ].join('\n');
+      createSessionDir('session-createdAt', events);
+
+      const result = readEventsHead('session-createdAt');
+
+      expect(result.createdAt).toBe('2026-06-15T10:30:00Z');
+    });
+  });
+
+  describe('no user messages', () => {
+    it('returns null firstUserMessage when no user.message events exist', () => {
+      const events = [
+        makeEvent('assistant.message', { content: 'Starting...' }, '2026-01-01T00:00:00Z'),
+        makeEvent('tool.result', { output: 'done' }, '2026-01-01T00:00:01Z'),
+      ].join('\n');
+      createSessionDir('session-no-user', events);
+
+      const result = readEventsHead('session-no-user');
+
+      expect(result.createdAt).toBe('2026-01-01T00:00:00Z');
+      expect(result.firstUserMessage).toBeNull();
+      expect(result.turnCount).toBe(0);
+    });
+  });
+
+  describe('empty and missing files', () => {
+    it('returns all null/0 for an empty events.jsonl', () => {
+      createSessionDir('session-empty', '');
+
+      const result = readEventsHead('session-empty');
+
+      expect(result.createdAt).toBeNull();
+      expect(result.firstUserMessage).toBeNull();
+      expect(result.turnCount).toBe(0);
+    });
+
+    it('returns all null/0 when events.jsonl does not exist', () => {
+      // Session dir exists but no events.jsonl
+      fs.mkdirSync(path.join(FIXTURES_DIR, 'session-no-file'), { recursive: true });
+
+      const result = readEventsHead('session-no-file');
+
+      expect(result.createdAt).toBeNull();
+      expect(result.firstUserMessage).toBeNull();
+      expect(result.turnCount).toBe(0);
+    });
+
+    it('returns all null/0 when session directory does not exist', () => {
+      const result = readEventsHead('session-nonexistent');
+
+      expect(result.createdAt).toBeNull();
+      expect(result.firstUserMessage).toBeNull();
+      expect(result.turnCount).toBe(0);
+    });
+  });
+
+  describe('large file — partial read', () => {
+    it('finds user message within the first 64KB', () => {
+      // Pad with assistant messages, then place a user message within 64KB
+      const lines: string[] = [];
+      for (let i = 0; i < 50; i++) {
+        lines.push(
+          makeEvent('assistant.message', { content: `Resp ${i} ${'x'.repeat(200)}` }, `2026-01-01T00:${String(i).padStart(2, '0')}:00Z`),
+        );
+      }
+      lines.push(makeEvent('user.message', { content: 'Found within 64KB' }, '2026-01-01T01:00:00Z'));
+      createSessionDir('session-within', lines.join('\n'));
+
+      const result = readEventsHead('session-within');
+
+      expect(result.createdAt).toBe('2026-01-01T00:00:00Z');
+      expect(result.firstUserMessage).toBe('Found within 64KB');
+      expect(result.turnCount).toBe(1);
+    });
+
+    it('does not find user message beyond maxBytes boundary', () => {
+      // Generate lines totalling > 64KB of padding BEFORE the user message
+      const lines: string[] = [];
+      const lineSize = 500;
+      const linesNeeded = Math.ceil(65536 / lineSize) + 30;
+      for (let i = 0; i < linesNeeded; i++) {
+        lines.push(
+          makeEvent('assistant.message', { content: `Pad ${i} ${'y'.repeat(400)}` }, `2026-01-01T00:${String(i % 60).padStart(2, '0')}:00Z`),
+        );
+      }
+      // Place user message well beyond 64KB
+      lines.push(makeEvent('user.message', { content: 'Beyond boundary' }, '2026-01-02T00:00:00Z'));
+      createSessionDir('session-beyond', lines.join('\n'));
+
+      const result = readEventsHead('session-beyond');
+
+      expect(result.createdAt).not.toBeNull();
+      expect(result.firstUserMessage).toBeNull();
+      expect(result.turnCount).toBe(0);
+    });
+
+    it('respects custom maxBytes parameter', () => {
+      const lines = [
+        makeEvent('user.message', { content: 'First line is short' }, '2026-01-01T00:00:00Z'),
+        makeEvent('user.message', { content: 'Second line too' }, '2026-01-01T00:00:01Z'),
+      ];
+      createSessionDir('session-custom-max', lines.join('\n'));
+
+      // Read with a very small maxBytes — only the first line should fit
+      const firstLineBytes = Buffer.byteLength(lines[0], 'utf8');
+      const result = readEventsHead('session-custom-max', firstLineBytes + 2);
+
+      expect(result.createdAt).toBe('2026-01-01T00:00:00Z');
+      expect(result.firstUserMessage).toBe('First line is short');
+      // The second user.message might be truncated and dropped
+      expect(result.turnCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('malformed data', () => {
+    it('skips malformed JSON lines and parses valid ones', () => {
+      const events = [
+        'not valid json at all',
+        '{"broken": true',
+        makeEvent('user.message', { content: 'Valid message' }, '2026-01-01T00:00:00Z'),
+        '{another broken}',
+        makeEvent('user.message', { content: 'Second valid' }, '2026-01-01T00:01:00Z'),
+      ].join('\n');
+      createSessionDir('session-malformed', events);
+
+      const result = readEventsHead('session-malformed');
+
+      expect(result.createdAt).toBe('2026-01-01T00:00:00Z');
+      expect(result.firstUserMessage).toBe('Valid message');
+      expect(result.turnCount).toBe(2);
+    });
+
+    it('returns all null/0 when entire file is malformed', () => {
+      createSessionDir('session-all-bad', 'garbage\nmore garbage\n{bad json}\n');
+
+      const result = readEventsHead('session-all-bad');
+
+      expect(result.createdAt).toBeNull();
+      expect(result.firstUserMessage).toBeNull();
+      expect(result.turnCount).toBe(0);
+    });
+  });
+
+  describe('edge cases — content filtering', () => {
+    it('skips user.message with empty content for firstUserMessage but still counts turns', () => {
+      const events = [
+        makeEvent('user.message', { content: '' }, '2026-01-01T00:00:00Z'),
+        makeEvent('user.message', { content: '   ' }, '2026-01-01T00:00:01Z'),
+        makeEvent('user.message', { content: 'Real message' }, '2026-01-01T00:00:02Z'),
+      ].join('\n');
+      createSessionDir('session-empty-content', events);
+
+      const result = readEventsHead('session-empty-content');
+
+      expect(result.firstUserMessage).toBe('Real message');
+      expect(result.turnCount).toBe(3);
+    });
+
+    it('trims whitespace from firstUserMessage', () => {
+      const events = [
+        makeEvent('user.message', { content: '  padded message  ' }, '2026-01-01T00:00:00Z'),
+      ].join('\n');
+      createSessionDir('session-trim', events);
+
+      const result = readEventsHead('session-trim');
+
+      expect(result.firstUserMessage).toBe('padded message');
+    });
+
+    it('handles blank lines between events', () => {
+      const events = [
+        makeEvent('user.message', { content: 'First' }, '2026-01-01T00:00:00Z'),
+        '',
+        '',
+        makeEvent('user.message', { content: 'Second' }, '2026-01-01T00:00:01Z'),
+      ].join('\n');
+      createSessionDir('session-blanks', events);
+
+      const result = readEventsHead('session-blanks');
+
+      expect(result.firstUserMessage).toBe('First');
+      expect(result.turnCount).toBe(2);
+    });
+  });
+});

--- a/server/services/__tests__/sessionMapperById.test.ts
+++ b/server/services/__tests__/sessionMapperById.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for mapSessionById — routing logic through the provider layer.
+ *
+ * Validates:
+ * - claude: prefix routes to ClaudeSessionSource
+ * - normal IDs route through CopilotSessionSource (not direct SQLite)
+ * - returns undefined when no source has the session
+ * - falls back to legacy SQLite when CopilotSessionSource is unavailable
+ */
+
+// ── Mock variables ──────────────────────────────────────────────
+
+const mockGetSourceByName = vi.fn();
+
+vi.mock('../providers/index.js', () => ({
+  getActiveSources: vi.fn(() => []),
+  getSourceByName: (...args: unknown[]) => mockGetSourceByName(...args),
+  getSessionSourcesConfig: vi.fn(() => 'auto'),
+}));
+
+const mockGetSessionById = vi.fn();
+
+vi.mock('../sqliteReader.js', () => ({
+  getAllSessions: vi.fn(() => []),
+  getSessionById: (...args: unknown[]) => mockGetSessionById(...args),
+  getFirstUserMessage: vi.fn(() => null),
+  getLastUserMessage: vi.fn(() => null),
+  getTurnCount: vi.fn(() => 0),
+  getSessionTurnDataBatch: vi.fn(() => new Map()),
+}));
+
+vi.mock('../eventTailReader.js', () => ({
+  readEventsTail: vi.fn(() => []),
+  readEventsHead: vi.fn(() => ({ createdAt: null, firstUserMessage: null, turnCount: 0 })),
+}));
+
+vi.mock('../statusDeriver.js', () => ({
+  deriveSessionStatus: vi.fn(() => ({
+    status: 'completed',
+    lastActivityAt: '2026-01-01T01:00:00Z',
+    blockedReason: undefined,
+    waitingFor: undefined,
+    waitingQuestion: undefined,
+    waitingChoices: undefined,
+    errorDetails: undefined,
+  })),
+  detectSquadSession: vi.fn(() => false),
+}));
+
+vi.mock('../agentTreeBuilder.js', () => ({
+  buildAgentTree: vi.fn(() => ({
+    name: 'root',
+    status: 'completed',
+    children: [],
+    events: [],
+    startedAt: '2026-01-01T00:00:00Z',
+    endedAt: '2026-01-01T01:00:00Z',
+  })),
+}));
+
+vi.mock('../eventTimelineBuilder.js', () => ({
+  buildEventTimeline: vi.fn(() => []),
+}));
+
+vi.mock('../activityBucketBuilder.js', () => ({
+  buildActivityBuckets: vi.fn(() => []),
+}));
+
+vi.mock('../squadCastExtractor.js', () => ({
+  extractSquadCast: vi.fn(() => []),
+}));
+
+vi.mock('../sessionSummaryCache.js', () => ({
+  getOrCompute: vi.fn((_id: string, _path: string, _updated: string, factory: () => unknown) => factory()),
+  evictStale: vi.fn(),
+}));
+
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    sessionStateDir: '/mock/session-state',
+    sqliteDbPath: '/mock/session-store.db',
+    tailBytes: 524288,
+    staleThresholdMs: 300000,
+    cacheTtlMs: 10000,
+    sessionSources: 'auto',
+  })),
+}));
+
+vi.mock('../../utils/sanitize.js', () => ({
+  sanitizeSessionId: (id: string) => id,
+}));
+
+import { mapSessionById } from '../sessionMapper.js';
+import type { Session } from '../../../src/types/index.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeSession(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: `Session ${id}`,
+    intent: 'Test',
+    status: 'completed',
+    startedAt: '2026-01-01T00:00:00Z',
+    lastActivityAt: '2026-01-01T01:00:00Z',
+    agentCount: 1,
+    turnCount: 3,
+    rootAgent: { name: 'root', status: 'completed', children: [], events: [], startedAt: '2026-01-01T00:00:00Z', endedAt: '2026-01-01T01:00:00Z' },
+    events: [],
+    activityBuckets: [],
+    compacted: false,
+    compactionCount: 0,
+    ...overrides,
+  } as Session;
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSourceByName.mockReturnValue(undefined);
+  mockGetSessionById.mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('mapSessionById — provider routing', () => {
+  describe('claude-prefixed IDs', () => {
+    it('routes claude: IDs to the Claude source', () => {
+      const claudeSession = makeSession('claude:abc-123', { source: 'claude' });
+      const mockClaudeSource = {
+        name: 'claude',
+        getSession: vi.fn(() => claudeSession),
+        listSessionSummaries: vi.fn(() => []),
+        isAvailable: vi.fn(() => true),
+      };
+      mockGetSourceByName.mockImplementation((name: string) =>
+        name === 'claude' ? mockClaudeSource : undefined,
+      );
+
+      const result = mapSessionById('claude:abc-123');
+
+      expect(result).toBeDefined();
+      expect(result!.id).toBe('claude:abc-123');
+      expect(mockClaudeSource.getSession).toHaveBeenCalledWith('claude:abc-123');
+    });
+
+    it('returns undefined when Claude source is not available', () => {
+      mockGetSourceByName.mockReturnValue(undefined);
+
+      const result = mapSessionById('claude:unknown');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when Claude source returns null', () => {
+      const mockClaudeSource = {
+        name: 'claude',
+        getSession: vi.fn(() => null),
+        listSessionSummaries: vi.fn(() => []),
+        isAvailable: vi.fn(() => true),
+      };
+      mockGetSourceByName.mockImplementation((name: string) =>
+        name === 'claude' ? mockClaudeSource : undefined,
+      );
+
+      const result = mapSessionById('claude:nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('normal IDs — CopilotSessionSource', () => {
+    it('routes normal IDs through CopilotSessionSource', () => {
+      const copilotSession = makeSession('normal-id', { source: 'copilot' });
+      const mockCopilotSource = {
+        name: 'copilot',
+        getSession: vi.fn(() => copilotSession),
+        listSessionSummaries: vi.fn(() => []),
+        isAvailable: vi.fn(() => true),
+      };
+      mockGetSourceByName.mockImplementation((name: string) =>
+        name === 'copilot' ? mockCopilotSource : undefined,
+      );
+
+      const result = mapSessionById('normal-id');
+
+      expect(result).toBeDefined();
+      expect(result!.id).toBe('normal-id');
+      expect(mockCopilotSource.getSession).toHaveBeenCalledWith('normal-id');
+    });
+
+    it('returns undefined when CopilotSessionSource returns null', () => {
+      const mockCopilotSource = {
+        name: 'copilot',
+        getSession: vi.fn(() => null),
+        listSessionSummaries: vi.fn(() => []),
+        isAvailable: vi.fn(() => true),
+      };
+      mockGetSourceByName.mockImplementation((name: string) =>
+        name === 'copilot' ? mockCopilotSource : undefined,
+      );
+
+      const result = mapSessionById('nonexistent-id');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('does NOT call getSessionById directly when CopilotSessionSource is available', () => {
+      const mockCopilotSource = {
+        name: 'copilot',
+        getSession: vi.fn(() => makeSession('some-id')),
+        listSessionSummaries: vi.fn(() => []),
+        isAvailable: vi.fn(() => true),
+      };
+      mockGetSourceByName.mockImplementation((name: string) =>
+        name === 'copilot' ? mockCopilotSource : undefined,
+      );
+
+      mapSessionById('some-id');
+
+      // getSessionById is the direct SQLite path — should NOT be called
+      expect(mockGetSessionById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('legacy fallback — CopilotSessionSource unavailable', () => {
+    it('falls back to direct SQLite lookup when CopilotSessionSource is undefined', () => {
+      // getSourceByName returns undefined for 'copilot'
+      mockGetSourceByName.mockReturnValue(undefined);
+
+      // Direct SQLite returns a session row
+      mockGetSessionById.mockReturnValue({
+        id: 'legacy-id',
+        cwd: '/repo',
+        repository: null,
+        branch: null,
+        summary: null,
+        host_type: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T01:00:00Z',
+      });
+
+      const result = mapSessionById('legacy-id');
+
+      expect(result).toBeDefined();
+      expect(result!.id).toBe('legacy-id');
+      expect(result!.source).toBe('copilot');
+      expect(mockGetSessionById).toHaveBeenCalledWith('legacy-id');
+    });
+
+    it('returns undefined when legacy SQLite also has no session', () => {
+      mockGetSourceByName.mockReturnValue(undefined);
+      mockGetSessionById.mockReturnValue(null);
+
+      const result = mapSessionById('totally-unknown');
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/server/services/eventTailReader.ts
+++ b/server/services/eventTailReader.ts
@@ -93,6 +93,88 @@ export function readEventsTail(sessionId: string): ParsedEvent[] {
   return events;
 }
 
+/* ── Head reader (first N bytes for session metadata) ────────── */
+
+export interface EventsHeadData {
+  createdAt: string | null;
+  firstUserMessage: string | null;
+  turnCount: number;
+}
+
+export function readEventsHead(sessionId: string, maxBytes = 65536): EventsHeadData {
+  const safeId = sanitizeSessionId(sessionId);
+  const { sessionStateDir } = getConfig();
+  const filePath = path.join(sessionStateDir, safeId, 'events.jsonl');
+
+  const result: EventsHeadData = {
+    createdAt: null,
+    firstUserMessage: null,
+    turnCount: 0,
+  };
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(filePath);
+  } catch {
+    return result;
+  }
+
+  if (stats.size === 0) {
+    return result;
+  }
+
+  const bytesToRead = Math.min(maxBytes, stats.size);
+  let content: string;
+
+  if (stats.size <= maxBytes) {
+    content = fs.readFileSync(filePath, 'utf8');
+  } else {
+    const buffer = Buffer.allocUnsafe(bytesToRead);
+    const fd = fs.openSync(filePath, 'r');
+    try {
+      const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead, 0);
+      content = buffer.toString('utf8', 0, bytesRead);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  const lines = content.split('\n');
+  // If we read a partial file, the last line may be incomplete — drop it
+  if (stats.size > maxBytes && lines.length > 0) {
+    lines.pop();
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    try {
+      const parsed = JSON.parse(line) as ParsedEvent;
+
+      // First event's timestamp = createdAt
+      if (result.createdAt === null && parsed.timestamp) {
+        result.createdAt = parsed.timestamp;
+      }
+
+      // Count user.message events for turnCount, capture first for name
+      if (parsed.type.toLowerCase() === 'user.message') {
+        result.turnCount++;
+        if (result.firstUserMessage === null) {
+          const data = parsed.data;
+          if (data && typeof data.content === 'string' && data.content.trim().length > 0) {
+            result.firstUserMessage = data.content.trim();
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed lines
+    }
+  }
+
+  return result;
+}
+
 export function clearCache(): void {
   cache.clear();
 }

--- a/server/services/providers/__tests__/copilotSourceFilesystem.test.ts
+++ b/server/services/providers/__tests__/copilotSourceFilesystem.test.ts
@@ -271,7 +271,7 @@ describe('CopilotSessionSource', () => {
 
       // mapToSession should be called with a synthetic SqliteSession row + events + context
       expect(mockMapToSession).toHaveBeenCalledTimes(1);
-      const [syntheticRow, _events, ctx] = mockMapToSession.mock.calls[0];
+      const [syntheticRow, , ctx] = mockMapToSession.mock.calls[0];
       expect(syntheticRow.id).toBe('ctx-session');
       expect(syntheticRow.created_at).toBe('2026-06-01T12:00:00Z');
       expect(ctx).toEqual({

--- a/server/services/providers/__tests__/copilotSourceFilesystem.test.ts
+++ b/server/services/providers/__tests__/copilotSourceFilesystem.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+
+/**
+ * Tests for CopilotSessionSource filesystem fallback behavior.
+ *
+ * When SQLite is absent (fresh user), the source discovers sessions from
+ * the ~/.copilot/session-state/ directories and builds synthetic session
+ * objects using readEventsHead() metadata.
+ */
+
+// ── Mock variables (hoisted for vi.mock factory access) ──────────
+
+const { mockExistsSync, mockReaddirSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReaddirSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: { ...actual, existsSync: mockExistsSync, readdirSync: mockReaddirSync },
+    existsSync: mockExistsSync,
+    readdirSync: mockReaddirSync,
+  };
+});
+
+const MOCK_SQLITE = '/mock/session-store.db';
+const MOCK_STATE_DIR = '/mock/session-state';
+
+vi.mock('../../../config.js', () => ({
+  getConfig: vi.fn(() => ({
+    sqliteDbPath: MOCK_SQLITE,
+    sessionStateDir: MOCK_STATE_DIR,
+    tailBytes: 524288,
+  })),
+}));
+
+const mockGetSessionById = vi.fn();
+const mockGetAllSessions = vi.fn();
+const mockGetSessionTurnDataBatch = vi.fn();
+
+vi.mock('../../sqliteReader.js', () => ({
+  getAllSessions: (...args: unknown[]) => mockGetAllSessions(...args),
+  getSessionById: (...args: unknown[]) => mockGetSessionById(...args),
+  getSessionTurnDataBatch: (...args: unknown[]) => mockGetSessionTurnDataBatch(...args),
+}));
+
+const mockReadEventsTail = vi.fn();
+const mockReadEventsHead = vi.fn();
+
+vi.mock('../../eventTailReader.js', () => ({
+  readEventsTail: (...args: unknown[]) => mockReadEventsTail(...args),
+  readEventsHead: (...args: unknown[]) => mockReadEventsHead(...args),
+}));
+
+const mockMapToSession = vi.fn();
+const mockMapSessionSummary = vi.fn();
+const mockGetSessionCwd = vi.fn();
+
+vi.mock('../../sessionMapper.js', () => ({
+  mapToSession: (...args: unknown[]) => mockMapToSession(...args),
+  mapSessionSummary: (...args: unknown[]) => mockMapSessionSummary(...args),
+  getSessionCwd: (...args: unknown[]) => mockGetSessionCwd(...args),
+}));
+
+const mockGetOrComputeSummary = vi.fn();
+
+vi.mock('../../sessionSummaryCache.js', () => ({
+  getOrCompute: (...args: unknown[]) => mockGetOrComputeSummary(...args),
+  evictStale: vi.fn(),
+}));
+
+vi.mock('../../../utils/sanitize.js', () => ({
+  sanitizeSessionId: (id: string) => id,
+}));
+
+import { CopilotSessionSource } from '../copilotSource.js';
+import type { Session, SessionSummary } from '../../../../src/types/index.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function eventsFilePath(sessionId: string): string {
+  return path.join(MOCK_STATE_DIR, sessionId, 'events.jsonl');
+}
+
+function makeSession(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: `Session ${id}`,
+    intent: 'Test',
+    status: 'completed',
+    startedAt: '2026-01-01T00:00:00Z',
+    lastActivityAt: '2026-01-01T01:00:00Z',
+    agentCount: 1,
+    turnCount: 3,
+    rootAgent: { name: 'root', status: 'completed', children: [], events: [], startedAt: '2026-01-01T00:00:00Z', endedAt: '2026-01-01T01:00:00Z' },
+    events: [],
+    activityBuckets: [],
+    compacted: false,
+    compactionCount: 0,
+    ...overrides,
+  } as Session;
+}
+
+function makeSummary(id: string, overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id,
+    name: `Session ${id}`,
+    intent: 'Test',
+    status: 'completed',
+    startedAt: '2026-01-01T00:00:00Z',
+    lastActivityAt: '2026-01-01T01:00:00Z',
+    agentCount: 1,
+    turnCount: 3,
+    compacted: false,
+    compactionCount: 0,
+    ...overrides,
+  };
+}
+
+function makeDirent(name: string, isDir: boolean) {
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    parentPath: MOCK_STATE_DIR,
+    path: MOCK_STATE_DIR,
+  };
+}
+
+// ── Setup ────────────────────────────────────────────────────────
+
+// Advance Date.now past the 10s filesystem ID cache TTL between tests
+let dateNow = 1_000_000_000;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dateNow += 20_000;
+  vi.spyOn(Date, 'now').mockImplementation(() => dateNow);
+
+  // Defaults: neither SQLite nor filesystem exists
+  mockExistsSync.mockReturnValue(false);
+  mockReaddirSync.mockReturnValue([]);
+  mockGetAllSessions.mockReturnValue([]);
+  mockGetSessionTurnDataBatch.mockReturnValue(new Map());
+  mockReadEventsTail.mockReturnValue([]);
+  mockReadEventsHead.mockReturnValue({ createdAt: null, firstUserMessage: null, turnCount: 0 });
+  mockGetSessionCwd.mockReturnValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('CopilotSessionSource', () => {
+  describe('isAvailable()', () => {
+    it('returns true when SQLite database exists', () => {
+      mockExistsSync.mockImplementation((p: string) => p === MOCK_SQLITE);
+
+      const source = new CopilotSessionSource();
+      expect(source.isAvailable()).toBe(true);
+    });
+
+    it('returns true when sessionStateDir exists (no SQLite)', () => {
+      mockExistsSync.mockImplementation((p: string) => p === MOCK_STATE_DIR);
+
+      const source = new CopilotSessionSource();
+      expect(source.isAvailable()).toBe(true);
+    });
+
+    it('returns true when both SQLite and sessionStateDir exist', () => {
+      mockExistsSync.mockImplementation((p: string) =>
+        p === MOCK_SQLITE || p === MOCK_STATE_DIR,
+      );
+
+      const source = new CopilotSessionSource();
+      expect(source.isAvailable()).toBe(true);
+    });
+
+    it('returns false when neither SQLite nor sessionStateDir exists', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const source = new CopilotSessionSource();
+      expect(source.isAvailable()).toBe(false);
+    });
+  });
+
+  describe('getSession(id) — SQLite path', () => {
+    it('returns session from SQLite when database has the session', () => {
+      const row = {
+        id: 'abc-123',
+        cwd: '/repo',
+        repository: 'rocinante',
+        branch: 'main',
+        summary: 'Test session',
+        host_type: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T01:00:00Z',
+      };
+      mockGetSessionById.mockReturnValue(row);
+      const session = makeSession('abc-123', { source: 'copilot' });
+      mockMapToSession.mockReturnValue(session);
+
+      const source = new CopilotSessionSource();
+      const result = source.getSession('abc-123');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('abc-123');
+      expect(result!.source).toBe('copilot');
+      expect(mockGetSessionById).toHaveBeenCalledWith('abc-123');
+    });
+  });
+
+  describe('getSession(id) — filesystem fallback', () => {
+    it('falls back to filesystem when SQLite returns null', () => {
+      mockGetSessionById.mockReturnValue(null);
+
+      // Filesystem: events.jsonl exists for this session
+      mockExistsSync.mockImplementation((p: string) => {
+        return p === eventsFilePath('fs-session-1');
+      });
+
+      mockReadEventsHead.mockReturnValue({
+        createdAt: '2026-06-01T00:00:00Z',
+        firstUserMessage: 'Fix the tests',
+        turnCount: 2,
+      });
+
+      const session = makeSession('fs-session-1');
+      mockMapToSession.mockReturnValue(session);
+
+      const source = new CopilotSessionSource();
+      const result = source.getSession('fs-session-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.source).toBe('copilot');
+      expect(mockReadEventsHead).toHaveBeenCalledWith('fs-session-1');
+    });
+
+    it('returns null when session does not exist in SQLite or filesystem', () => {
+      mockGetSessionById.mockReturnValue(null);
+      mockExistsSync.mockReturnValue(false);
+
+      const source = new CopilotSessionSource();
+      const result = source.getSession('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('passes SessionMappingContext with head data to mapToSession', () => {
+      mockGetSessionById.mockReturnValue(null);
+      mockExistsSync.mockImplementation((p: string) => p === eventsFilePath('ctx-session'));
+      mockReadEventsHead.mockReturnValue({
+        createdAt: '2026-06-01T12:00:00Z',
+        firstUserMessage: 'Create the feature',
+        turnCount: 5,
+      });
+      mockMapToSession.mockReturnValue(makeSession('ctx-session'));
+
+      const source = new CopilotSessionSource();
+      source.getSession('ctx-session');
+
+      // mapToSession should be called with a synthetic SqliteSession row + events + context
+      expect(mockMapToSession).toHaveBeenCalledTimes(1);
+      const [syntheticRow, _events, ctx] = mockMapToSession.mock.calls[0];
+      expect(syntheticRow.id).toBe('ctx-session');
+      expect(syntheticRow.created_at).toBe('2026-06-01T12:00:00Z');
+      expect(ctx).toEqual({
+        firstUserMessage: 'Create the feature',
+        turnCount: 5,
+      });
+    });
+
+    it('handles corrupt events.jsonl gracefully (readEventsHead returns defaults)', () => {
+      mockGetSessionById.mockReturnValue(null);
+      mockExistsSync.mockImplementation((p: string) => p === eventsFilePath('corrupt'));
+      mockReadEventsHead.mockReturnValue({ createdAt: null, firstUserMessage: null, turnCount: 0 });
+      mockMapToSession.mockReturnValue(makeSession('corrupt'));
+
+      const source = new CopilotSessionSource();
+      const result = source.getSession('corrupt');
+
+      expect(result).not.toBeNull();
+    });
+
+    it('returns null when buildSessionFromFilesystem throws', () => {
+      mockGetSessionById.mockReturnValue(null);
+      mockExistsSync.mockImplementation((p: string) => p === eventsFilePath('error'));
+      mockReadEventsHead.mockImplementation(() => {
+        throw new Error('Disk I/O error');
+      });
+
+      const source = new CopilotSessionSource();
+      const result = source.getSession('error');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listSessionSummaries() — filesystem merge', () => {
+    it('includes filesystem-only sessions not present in SQLite', () => {
+      // SQLite has no sessions
+      mockGetAllSessions.mockReturnValue([]);
+
+      // Filesystem has one session directory
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === MOCK_STATE_DIR) return true;
+        if (p === eventsFilePath('fs-only-1')) return true;
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([makeDirent('fs-only-1', true)]);
+
+      // When building the filesystem session, mapToSession returns a session
+      const session = makeSession('fs-only-1', { source: 'copilot' });
+      mockMapToSession.mockReturnValue(session);
+      mockReadEventsHead.mockReturnValue({
+        createdAt: '2026-06-01T00:00:00Z',
+        firstUserMessage: 'Hello',
+        turnCount: 1,
+      });
+
+      const source = new CopilotSessionSource();
+      const summaries = source.listSessionSummaries();
+
+      // Should contain the filesystem-only session
+      expect(summaries.some(s => s.id === 'fs-only-1')).toBe(true);
+    });
+
+    it('deduplicates sessions present in both SQLite and filesystem', () => {
+      // SQLite has session "shared-1"
+      const row = {
+        id: 'shared-1',
+        cwd: '/repo',
+        repository: null,
+        branch: null,
+        summary: null,
+        host_type: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T01:00:00Z',
+      };
+      mockGetAllSessions.mockReturnValue([row]);
+      mockGetSessionTurnDataBatch.mockReturnValue(
+        new Map([['shared-1', { firstMessage: 'Hi', lastMessage: 'Bye', turnCount: 2 }]]),
+      );
+
+      // getOrComputeSummary returns a pre-built summary
+      const sqliteSummary = makeSummary('shared-1', { source: 'copilot' });
+      mockGetOrComputeSummary.mockImplementation(
+        (_id: string, _path: string, _updated: string, factory: () => SessionSummary) => factory(),
+      );
+      mockMapSessionSummary.mockReturnValue(sqliteSummary);
+      mockReadEventsTail.mockReturnValue([]);
+
+      // Filesystem ALSO has "shared-1"
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === MOCK_STATE_DIR) return true;
+        if (p === eventsFilePath('shared-1')) return true;
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([makeDirent('shared-1', true)]);
+
+      const source = new CopilotSessionSource();
+      const summaries = source.listSessionSummaries();
+
+      // "shared-1" should appear exactly once (from SQLite, not duplicated)
+      const matches = summaries.filter(s => s.id === 'shared-1');
+      expect(matches).toHaveLength(1);
+    });
+
+    it('respects excludeIds for filesystem sessions', () => {
+      mockGetAllSessions.mockReturnValue([]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === MOCK_STATE_DIR) return true;
+        if (p === eventsFilePath('excluded')) return true;
+        if (p === eventsFilePath('included')) return true;
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([
+        makeDirent('excluded', true),
+        makeDirent('included', true),
+      ]);
+      mockMapToSession.mockImplementation(
+        (row: { id: string }) => makeSession(row.id, { source: 'copilot' }),
+      );
+      mockReadEventsHead.mockReturnValue({
+        createdAt: '2026-01-01T00:00:00Z',
+        firstUserMessage: null,
+        turnCount: 0,
+      });
+
+      const source = new CopilotSessionSource();
+      const summaries = source.listSessionSummaries(new Set(['excluded']));
+
+      expect(summaries.some(s => s.id === 'excluded')).toBe(false);
+      expect(summaries.some(s => s.id === 'included')).toBe(true);
+    });
+
+    it('skips non-directory entries in sessionStateDir', () => {
+      mockGetAllSessions.mockReturnValue([]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === MOCK_STATE_DIR) return true;
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([
+        makeDirent('some-file.txt', false), // not a directory
+        makeDirent('.DS_Store', false),
+      ]);
+
+      const source = new CopilotSessionSource();
+      const summaries = source.listSessionSummaries();
+
+      expect(summaries).toHaveLength(0);
+    });
+
+    it('skips directories without events.jsonl', () => {
+      mockGetAllSessions.mockReturnValue([]);
+      mockExistsSync.mockImplementation((p: string) => {
+        if (p === MOCK_STATE_DIR) return true;
+        // No events.jsonl for either session
+        return false;
+      });
+      mockReaddirSync.mockReturnValue([
+        makeDirent('session-no-events', true),
+      ]);
+
+      const source = new CopilotSessionSource();
+      const summaries = source.listSessionSummaries();
+
+      expect(summaries).toHaveLength(0);
+    });
+  });
+});

--- a/server/services/providers/copilotSource.ts
+++ b/server/services/providers/copilotSource.ts
@@ -7,9 +7,11 @@ import {
   getAllSessions,
   getSessionById,
   getSessionTurnDataBatch,
+  type SqliteSession,
 } from '../sqliteReader.js';
 import { readEventsTail } from '../eventTailReader.js';
-import { mapToSession, mapSessionSummary } from '../sessionMapper.js';
+import { readEventsHead } from '../eventTailReader.js';
+import { mapToSession, mapSessionSummary, getSessionCwd, type SessionMappingContext } from '../sessionMapper.js';
 import { getOrCompute as getOrComputeSummary, evictStale as evictStaleSummaries } from '../sessionSummaryCache.js';
 import { sanitizeSessionId } from '../../utils/sanitize.js';
 
@@ -18,12 +20,112 @@ function toEpochMs(timestamp: string): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
+/* ── Filesystem session ID discovery cache ────────────────────── */
+
+let fsIdCache: { ids: string[]; expires: number } | null = null;
+const FS_CACHE_TTL_MS = 10_000;
+
 export class CopilotSessionSource implements SessionSource {
   readonly name: SessionSourceName = 'copilot';
 
   isAvailable(): boolean {
-    const { sqliteDbPath } = getConfig();
-    return fs.existsSync(sqliteDbPath);
+    const { sqliteDbPath, sessionStateDir } = getConfig();
+    return fs.existsSync(sqliteDbPath) || fs.existsSync(sessionStateDir);
+  }
+
+  private discoverFilesystemSessionIds(): string[] {
+    const now = Date.now();
+    if (fsIdCache && now < fsIdCache.expires) {
+      return fsIdCache.ids;
+    }
+
+    const { sessionStateDir } = getConfig();
+    const ids: string[] = [];
+
+    try {
+      if (!fs.existsSync(sessionStateDir)) {
+        fsIdCache = { ids: [], expires: now + FS_CACHE_TTL_MS };
+        return ids;
+      }
+
+      const entries = fs.readdirSync(sessionStateDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const eventsPath = path.join(sessionStateDir, entry.name, 'events.jsonl');
+        try {
+          if (fs.existsSync(eventsPath)) {
+            ids.push(entry.name);
+          }
+        } catch {
+          // Skip entries we can't stat
+        }
+      }
+    } catch {
+      // sessionStateDir unreadable
+    }
+
+    fsIdCache = { ids, expires: now + FS_CACHE_TTL_MS };
+    return ids;
+  }
+
+  private buildSessionFromFilesystem(id: string): Session | null {
+    try {
+      const safeId = sanitizeSessionId(id);
+      const { sessionStateDir } = getConfig();
+      const eventsPath = path.join(sessionStateDir, safeId, 'events.jsonl');
+
+      if (!fs.existsSync(eventsPath)) {
+        return null;
+      }
+
+      const headData = readEventsHead(id);
+      const tailEvents = readEventsTail(id);
+
+      const cwd = getSessionCwd(id, null);
+      const now = new Date().toISOString();
+
+      const syntheticRow: SqliteSession = {
+        id,
+        cwd,
+        repository: null,
+        branch: null,
+        summary: null,
+        host_type: null,
+        created_at: headData.createdAt || now,
+        updated_at: tailEvents.length > 0
+          ? tailEvents[tailEvents.length - 1].timestamp
+          : (headData.createdAt || now),
+      };
+
+      const ctx: SessionMappingContext = {
+        firstUserMessage: headData.firstUserMessage,
+        turnCount: headData.turnCount,
+      };
+
+      const session = mapToSession(syntheticRow, tailEvents, ctx);
+      session.source = 'copilot';
+      return session;
+    } catch (error) {
+      console.warn('[CopilotSessionSource] Failed to build session from filesystem.', { sessionId: id, error });
+      return null;
+    }
+  }
+
+  private buildSummaryFromFilesystem(id: string): SessionSummary | null {
+    const session = this.buildSessionFromFilesystem(id);
+    if (!session) return null;
+
+    // Extract the summary fields from the full Session object
+    const {
+      rootAgent: _rootAgent,
+      events: _events,
+      activityBuckets: _buckets,
+      assistantUpdates: _updates,
+      squadCast: _cast,
+      ...summary
+    } = session;
+
+    return summary as SessionSummary;
   }
 
   listSessionSummaries(excludeIds?: Set<string>): SessionSummary[] {
@@ -41,6 +143,7 @@ export class CopilotSessionSource implements SessionSource {
     const { sessionStateDir } = getConfig();
 
     const summaries: SessionSummary[] = [];
+    const sqliteIdSet = new Set(allRows.map((r) => r.id));
 
     for (const row of rows) {
       try {
@@ -72,6 +175,25 @@ export class CopilotSessionSource implements SessionSource {
       }
     }
 
+    // Merge filesystem-only sessions not present in SQLite
+    const fsIds = this.discoverFilesystemSessionIds();
+    for (const fsId of fsIds) {
+      if (sqliteIdSet.has(fsId)) continue;
+      if (excludeIds && excludeIds.has(fsId)) continue;
+
+      try {
+        const summary = this.buildSummaryFromFilesystem(fsId);
+        if (summary) {
+          summaries.push(summary);
+        }
+      } catch (error) {
+        console.warn('[CopilotSessionSource] Failed to build filesystem summary. Skipping.', {
+          sessionId: fsId,
+          error,
+        });
+      }
+    }
+
     summaries.sort(
       (a, b) => toEpochMs(b.lastActivityAt) - toEpochMs(a.lastActivityAt),
     );
@@ -80,22 +202,20 @@ export class CopilotSessionSource implements SessionSource {
   }
 
   getSession(id: string): Session | null {
+    // Try SQLite first (fast, richer metadata)
     const row = getSessionById(id);
-    if (!row) {
-      return null;
+    if (row) {
+      try {
+        const events = readEventsTail(id);
+        const session = mapToSession(row, events);
+        session.source = 'copilot';
+        return session;
+      } catch (error) {
+        console.warn('[CopilotSessionSource] Failed to map session from SQLite.', { sessionId: id, error });
+      }
     }
 
-    try {
-      const events = readEventsTail(id);
-      const session = mapToSession(row, events);
-      session.source = 'copilot';
-      return session;
-    } catch (error) {
-      console.warn('[CopilotSessionSource] Failed to map session by id.', {
-        sessionId: id,
-        error,
-      });
-      return null;
-    }
+    // Filesystem fallback
+    return this.buildSessionFromFilesystem(id);
   }
 }

--- a/server/services/providers/copilotSource.ts
+++ b/server/services/providers/copilotSource.ts
@@ -116,14 +116,8 @@ export class CopilotSessionSource implements SessionSource {
     if (!session) return null;
 
     // Extract the summary fields from the full Session object
-    const {
-      rootAgent: _rootAgent,
-      events: _events,
-      activityBuckets: _buckets,
-      assistantUpdates: _updates,
-      squadCast: _cast,
-      ...summary
-    } = session;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { rootAgent, events, activityBuckets, assistantUpdates, squadCast, ...summary } = session;
 
     return summary as SessionSummary;
   }

--- a/server/services/providers/types.ts
+++ b/server/services/providers/types.ts
@@ -8,3 +8,16 @@ export interface SessionSource {
   getSession(id: string): Session | null;
   isAvailable(): boolean;
 }
+
+export interface SourceStatus {
+  copilot: {
+    available: boolean;
+    sqliteAvailable: boolean;
+    filesystemAvailable: boolean;
+    sessionStateDir: string;
+  };
+  claude: {
+    available: boolean;
+    claudeDir: string;
+  };
+}

--- a/server/services/sessionMapper.ts
+++ b/server/services/sessionMapper.ts
@@ -30,6 +30,13 @@ const MAX_NAME_LENGTH = 80;
 const MAX_INTENT_LENGTH = 200;
 const UNTITLED_SESSION_NAME = 'Untitled session';
 
+/* ── Optional context for filesystem-derived session data ─────── */
+
+export interface SessionMappingContext {
+  firstUserMessage?: string | null;
+  turnCount?: number;
+}
+
 /* ── Git context fallback (branch + repository from cwd) ──────── */
 
 interface GitContext {
@@ -142,7 +149,7 @@ function toEpochMs(timestamp: string): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-function getSessionCwd(sessionId: string, sqlCwd: string | null): string | null {
+export function getSessionCwd(sessionId: string, sqlCwd: string | null): string | null {
   if (sqlCwd && sqlCwd.trim().length > 0) {
     return sqlCwd;
   }
@@ -244,8 +251,8 @@ function resolveLatestUserMessage(
   return undefined;
 }
 
-export function mapToSession(sqlRow: SqliteSession, events: ParsedEvent[]): Session {
-  const firstUserMessage = getFirstUserMessage(sqlRow.id);
+export function mapToSession(sqlRow: SqliteSession, events: ParsedEvent[], ctx?: SessionMappingContext): Session {
+  const firstUserMessage = ctx?.firstUserMessage !== undefined ? ctx.firstUserMessage : getFirstUserMessage(sqlRow.id);
   const name = getSessionName(sqlRow, firstUserMessage);
   const intent = getSessionIntent(firstUserMessage, name);
   const derivedStatus: DerivedStatus = deriveSessionStatus(events, sqlRow.updated_at);
@@ -264,6 +271,7 @@ export function mapToSession(sqlRow: SqliteSession, events: ParsedEvent[]): Sess
   const gitFallback = resolveGitContext(resolvedCwd);
   const isSquad = detectSquadSession(events);
   const squadCast = isSquad ? extractSquadCast(events) : undefined;
+  const resolvedTurnCount = ctx?.turnCount !== undefined ? ctx.turnCount : getTurnCount(sqlRow.id);
 
   return {
     id: sqlRow.id,
@@ -273,7 +281,7 @@ export function mapToSession(sqlRow: SqliteSession, events: ParsedEvent[]): Sess
     startedAt: sqlRow.created_at,
     lastActivityAt: derivedStatus.lastActivityAt,
     agentCount: countAgentsInTree(rootAgent),
-    turnCount: getTurnCount(sqlRow.id),
+    turnCount: resolvedTurnCount,
     rootAgent,
     events: buildEventTimeline(events),
     activityBuckets: buildActivityBuckets(events, sqlRow.created_at, derivedStatus.lastActivityAt),
@@ -362,7 +370,13 @@ export function mapSessionById(id: string): Session | undefined {
     return claudeSource.getSession(id) ?? undefined;
   }
 
-  // Default: Copilot lookup
+  // Always use CopilotSessionSource — handles both SQLite and filesystem fallback
+  const copilotSource = getSourceByName('copilot');
+  if (copilotSource) {
+    return copilotSource.getSession(id) ?? undefined;
+  }
+
+  // Legacy fallback: direct SQLite lookup
   const row = getSessionById(id);
   if (!row) {
     return undefined;

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -18,6 +18,7 @@ import StatusSummaryBar from '../common/StatusSummaryBar';
 import StatusFilter from '../filters/StatusFilter';
 import KanbanColumn, { COLUMN_SORTABLE_PREFIX } from './KanbanColumn';
 import KanbanTile from './KanbanTile';
+import WelcomeCard from '../sessions/WelcomeCard';
 
 /* ─────────────────────────────────────────────────────────
  * KanbanBoard
@@ -238,6 +239,7 @@ export default function KanbanBoard() {
 
   const showSkeletons = isLoading && sessions.length === 0;
   const showErrorState = !isLoading && Boolean(error) && sessions.length === 0;
+  const showEmptyState = !isLoading && !error && sessions.length === 0 && !searchQuery.trim();
 
   return (
     <section className="flex h-full flex-col bg-surface-primary">
@@ -421,6 +423,8 @@ export default function KanbanBoard() {
               <p className="max-w-xs text-xs text-fg/45">{error}</p>
             </div>
           </div>
+        ) : showEmptyState ? (
+          <WelcomeCard />
         ) : (
           <DndContext
             sensors={sensors}

--- a/src/components/sessions/SessionDetail.tsx
+++ b/src/components/sessions/SessionDetail.tsx
@@ -1,8 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSettingsContext } from '../../context/SettingsContext';
 import { useSessionSelection, useSessionActions, useSessionData } from '../../context/SessionContext';
 import { useTerminalContext } from '../../context/TerminalContext';
 import type { SubAgent, AgentStatus, ErrorDetail } from '../../types';
+import type { AdoPullRequest } from '../../types/ado';
+import { getAdoStatus } from '../../services/adoService';
+import { useSessionDeliverables } from '../../hooks/useSessionDeliverables';
 import {
   formatRelativeTime,
   formatDuration,
@@ -225,6 +228,43 @@ function FolderIcon() {
   );
 }
 
+/* ── ADO deliverables styling helpers ─────────────────────────
+ *  Colour-code PR statuses and work-item states at a glance. */
+
+function deliverablePrStatusBadgeClasses(status: AdoPullRequest['status']): string {
+  switch (status) {
+    case 'active':
+      return 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30';
+    case 'draft':
+      return 'bg-amber-500/15 text-amber-400 border-amber-500/30';
+    case 'completed':
+      return 'bg-fg/[.08] text-fg/40 border-fg/[.12]';
+    case 'abandoned':
+      return 'bg-red-500/15 text-red-400 border-red-500/30';
+    default:
+      return 'bg-fg/[.08] text-fg/40 border-fg/[.12]';
+  }
+}
+
+function deliverableWorkItemStateBadgeClasses(state: string): string {
+  switch (state.toLowerCase()) {
+    case 'active':
+      return 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30';
+    case 'new':
+      return 'bg-blue-500/15 text-blue-400 border-blue-500/30';
+    case 'resolved':
+      return 'bg-amber-500/15 text-amber-400 border-amber-500/30';
+    case 'closed':
+      return 'bg-fg/[.08] text-fg/40 border-fg/[.12]';
+    default:
+      return 'bg-fg/[.08] text-fg/40 border-fg/[.12]';
+  }
+}
+
+function deliverableShortBranch(ref: string): string {
+  return ref.replace(/^refs\/heads\//, '');
+}
+
 /* ── Stat card (quick-stats grid item) ────────────────────────
  *  A compact, color-coded tile for a single agent-status count.
  *  Zero-count cards are dimmed so attention stays on what matters. */
@@ -291,6 +331,7 @@ function ExpandablePrompt({ text }: { text: string }) {
 export default function SessionDetail() {
   const {
     selectedSession,
+    selectedSessionId,
   } = useSessionSelection();
   const {
     isArchived,
@@ -314,11 +355,53 @@ export default function SessionDetail() {
   const [editNameValue, setEditNameValue] = useState('');
   const [errorExpanded, setErrorExpanded] = useState(false);
   const [agentHierarchyExpanded, setAgentHierarchyExpanded] = useState(false);
+  const [isAdoConfigured, setIsAdoConfigured] = useState(false);
+
+  // Fetch ADO configured status once on mount
+  useEffect(() => {
+    let isCancelled = false;
+
+    getAdoStatus()
+      .then((status) => {
+        if (!isCancelled) {
+          setIsAdoConfigured(status.configured);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  // Session deliverables hook — must be called before early return (rules of hooks)
+  const deliverables = useSessionDeliverables(selectedSession?.branch, isAdoConfigured);
+  const deliverablesCount = deliverables.pullRequests.length + deliverables.workItems.length;
+  const [deliverablesExpanded, setDeliverablesExpanded] = useState(true);
 
   /* ── Empty state ────────────────────────────────────────────
    *  Centred welcome screen — feels intentional, not broken.
    *  The panel-layout icon hints at the master–detail pattern. */
   if (!selectedSession) {
+    // Session selected but detail not yet loaded (loading or 404)
+    if (selectedSessionId) {
+      return (
+        <div className="flex h-full items-center justify-center p-6 select-none">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="text-2xl" aria-hidden="true">🔄</div>
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-fg/40">
+                Session data is loading…
+              </p>
+              <p className="max-w-[280px] text-xs leading-relaxed text-fg/20">
+                If this persists, the session may still be indexing. Try refreshing in a moment.
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="flex h-full items-center justify-center p-6 select-none">
         <div className="flex flex-col items-center gap-4 text-center">
@@ -861,6 +944,171 @@ export default function SessionDetail() {
                   </div>
                 )}
               </div>
+            </div>
+          </section>
+        )}
+
+        {/* ── 1d · Deliverables (ADO PRs + Work Items) ─────── */}
+        {isAdoConfigured && session.branch && (
+          <section>
+            <div className="rounded-lg border border-border-default bg-surface-secondary px-3.5 py-3">
+              {/* Header — collapsible with count badge */}
+              <button
+                type="button"
+                onClick={() => setDeliverablesExpanded((v) => !v)}
+                className="flex w-full items-center gap-2 cursor-pointer"
+              >
+                <svg
+                  className="h-3.5 w-3.5 shrink-0 text-fg/50"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="2" y="2" width="12" height="12" rx="2" />
+                  <path d="M5 6l3 3 3-3" />
+                </svg>
+                <h3 className="font-mono text-[11px] font-medium uppercase tracking-widest text-fg/60">
+                  ADO
+                </h3>
+                {!deliverables.isLoading && deliverablesCount > 0 && (
+                  <span className="font-mono text-[11px] tabular-nums text-fg/20">
+                    {deliverablesCount}
+                  </span>
+                )}
+                <span className="ml-auto font-mono text-[10px] text-fg/20">
+                  {deliverablesExpanded ? '▲' : '▼'}
+                </span>
+              </button>
+
+              {deliverablesExpanded && (
+                <div className="mt-2 space-y-3">
+                  {/* Loading state */}
+                  {deliverables.isLoading && deliverablesCount === 0 && (
+                    <div className="flex items-center gap-2 py-3">
+                      <div className="h-3 w-3 animate-spin rounded-full border border-fg/10 border-t-fg/30" />
+                      <span className="font-mono text-[11px] text-fg/50">Loading ADO data…</span>
+                    </div>
+                  )}
+
+                  {/* Error state */}
+                  {deliverables.error && (
+                    <div className="flex items-center gap-2 py-2">
+                      <svg
+                        className="h-3.5 w-3.5 shrink-0 text-red-400"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <circle cx="8" cy="8" r="6" />
+                        <line x1="8" y1="5" x2="8" y2="8.5" />
+                        <circle cx="8" cy="11" r="0.5" fill="currentColor" />
+                      </svg>
+                      <span className="text-xs text-red-400">{deliverables.error}</span>
+                      <button
+                        type="button"
+                        onClick={deliverables.refresh}
+                        className="ml-auto font-mono text-[10px] text-fg/40 hover:text-fg/60 cursor-pointer"
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Empty state */}
+                  {!deliverables.isLoading && !deliverables.error && deliverablesCount === 0 && (
+                    <p className="py-2 font-mono text-[11px] text-fg/50">
+                      No ADO data found
+                    </p>
+                  )}
+
+                  {/* Pull Requests */}
+                  {deliverables.pullRequests.length > 0 && (
+                    <div>
+                      <p className="mb-1 font-mono text-[10px] font-medium uppercase tracking-wider text-fg/30">
+                        Pull Requests
+                      </p>
+                      <div className="divide-y divide-border-default">
+                        {deliverables.pullRequests.map((pr) => (
+                          <a
+                            key={pr.id}
+                            href={pr.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="group/pr block w-full py-2 transition-colors hover:bg-surface-hover"
+                          >
+                            <div className="flex items-center gap-3">
+                              <span className="shrink-0 font-mono text-xs tabular-nums text-fg/45">
+                                PR #{pr.id}
+                              </span>
+                              <span className="min-w-0 flex-1 truncate text-sm text-fg/70">
+                                {pr.title}
+                              </span>
+                              <span
+                                className={`shrink-0 rounded-full border px-1.5 py-px font-mono text-[10px] font-medium capitalize leading-snug ${deliverablePrStatusBadgeClasses(pr.status)}`}
+                              >
+                                {pr.status}
+                              </span>
+                            </div>
+                            <div className="mt-1 flex items-center gap-1 font-mono text-[10px] text-fg/50">
+                              <span className="max-w-[120px] truncate">{deliverableShortBranch(pr.sourceBranch)}</span>
+                              <span aria-hidden="true">→</span>
+                              <span className="max-w-[120px] truncate">{deliverableShortBranch(pr.targetBranch)}</span>
+                            </div>
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Work Items */}
+                  {deliverables.workItems.length > 0 && (
+                    <div>
+                      <p className="mb-1 font-mono text-[10px] font-medium uppercase tracking-wider text-fg/30">
+                        Work Items
+                      </p>
+                      <div className="divide-y divide-border-default">
+                        {deliverables.workItems.map((item) => (
+                          <a
+                            key={item.id}
+                            href={item.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex w-full items-center gap-3 py-2 transition-colors hover:bg-surface-hover"
+                          >
+                            <span className="shrink-0 font-mono text-xs tabular-nums text-fg/45">
+                              #{item.id}
+                            </span>
+                            <span className="min-w-0 flex-1 truncate text-sm text-fg/70">
+                              {item.title}
+                            </span>
+                            <span
+                              className={`shrink-0 rounded-full border px-1.5 py-px font-mono text-[10px] font-medium leading-snug ${deliverableWorkItemStateBadgeClasses(item.state)}`}
+                            >
+                              {item.state}
+                            </span>
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Refreshing overlay when data already present */}
+                  {deliverables.isLoading && deliverablesCount > 0 && (
+                    <div className="flex items-center gap-2 border-t border-border-default pt-1.5">
+                      <div className="h-2.5 w-2.5 animate-spin rounded-full border border-fg/10 border-t-fg/30" />
+                      <span className="font-mono text-[10px] text-fg/50">Refreshing…</span>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </section>
         )}

--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -6,6 +6,7 @@ import StatusSummaryBar from '../common/StatusSummaryBar';
 import StatusFilter from '../filters/StatusFilter';
 import SessionCard from './SessionCard';
 import SessionGroup from './SessionGroup';
+import WelcomeCard from './WelcomeCard';
 
 const SKELETON_CARD_COUNT = 5;
 const ESTIMATED_ROW_HEIGHT = 110;
@@ -327,31 +328,32 @@ export default function SessionList() {
             </div>
           </div>
         ) : showEmptyState ? (
-          <div className="flex h-full min-h-48 items-center justify-center text-center">
-            <div className="space-y-2">
-              <div className="text-2xl opacity-40" aria-hidden="true">
-                {archivedCount > 0 && !searchQuery ? '📦' : '📭'}
-              </div>
-              {archivedCount > 0 && !searchQuery ? (
-                <>
-                  <p className="text-sm text-fg/45">All sessions archived</p>
-                  <button
-                    type="button"
-                    onClick={() => setShowArchived(true)}
-                    className="cursor-pointer text-xs text-border-active transition-colors hover:text-fg/70"
-                  >
-                    Show archived sessions →
-                  </button>
-                </>
-              ) : (
+          searchQuery ? (
+            <div className="flex h-full min-h-48 items-center justify-center text-center">
+              <div className="space-y-2">
+                <div className="text-2xl opacity-40" aria-hidden="true">📭</div>
                 <p className="text-sm text-fg/45">
-                  {searchQuery
-                    ? `No sessions matching '${searchQuery}'`
-                    : 'No sessions found'}
+                  No sessions matching &apos;{searchQuery}&apos;
                 </p>
-              )}
+              </div>
             </div>
-          </div>
+          ) : archivedCount > 0 ? (
+            <div className="flex h-full min-h-48 items-center justify-center text-center">
+              <div className="space-y-2">
+                <div className="text-2xl opacity-40" aria-hidden="true">📦</div>
+                <p className="text-sm text-fg/45">All sessions archived</p>
+                <button
+                  type="button"
+                  onClick={() => setShowArchived(true)}
+                  className="cursor-pointer text-xs text-border-active transition-colors hover:text-fg/70"
+                >
+                  Show archived sessions →
+                </button>
+              </div>
+            </div>
+          ) : (
+            <WelcomeCard />
+          )
         ) : hasAnyWorkstreams ? (
           /* ── Grouped view: sessions organized by workstream ── */
           <div className="space-y-1">

--- a/src/components/sessions/WelcomeCard.tsx
+++ b/src/components/sessions/WelcomeCard.tsx
@@ -1,0 +1,71 @@
+import { useSourceStatus } from '../../hooks/useSourceStatus';
+
+function StatusLine({ icon, text, dim }: { icon: string; text: string; dim?: boolean }) {
+  return (
+    <div className={`flex items-center gap-2 text-xs ${dim ? 'text-fg/25' : 'text-fg/50'}`}>
+      <span className="w-4 text-center" aria-hidden="true">{icon}</span>
+      <span>{text}</span>
+    </div>
+  );
+}
+
+export default function WelcomeCard() {
+  const { sources, isLoading } = useSourceStatus();
+
+  return (
+    <div className="flex h-full min-h-48 items-center justify-center p-6">
+      <div className="w-full max-w-sm space-y-5">
+        {/* Header */}
+        <div className="space-y-1.5 text-center">
+          <h2 className="text-base font-medium text-fg/70">
+            Welcome to Rocinante
+          </h2>
+          <p className="text-xs leading-relaxed text-fg/35">
+            Your AI coding sessions will appear here automatically.
+          </p>
+        </div>
+
+        {/* Source detection */}
+        <div className="rounded-lg border border-border bg-surface-secondary/40 p-3 space-y-2">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-fg/25">
+            Source Detection
+          </p>
+
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-xs text-fg/25">
+              <span className="inline-block h-3 w-3 animate-spin rounded-full border border-fg/15 border-t-fg/40" />
+              <span>Checking sources…</span>
+            </div>
+          ) : sources ? (
+            <div className="space-y-1.5">
+              <StatusLine
+                icon={sources.copilot.available ? '✅' : '⚠️'}
+                text={sources.copilot.available
+                  ? 'Copilot CLI detected'
+                  : 'Copilot CLI not detected — sessions stored in ~/.copilot/'}
+              />
+              <StatusLine
+                icon={sources.claude.available ? '✅' : '○'}
+                text={sources.claude.available
+                  ? 'Claude CLI detected'
+                  : 'Claude CLI not configured'}
+                dim={!sources.claude.available}
+              />
+            </div>
+          ) : (
+            <p className="text-xs text-fg/25">
+              Status endpoint unavailable — sources will be detected on first session.
+            </p>
+          )}
+        </div>
+
+        {/* Getting started hint */}
+        <div className="text-center">
+          <p className="text-xs leading-relaxed text-fg/30">
+            Run a Copilot or Claude session, then refresh to see it here.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -37,6 +37,7 @@ export interface SessionDataContextValue {
 // ── Selection Context — changes on click ──────────────────────
 export interface SessionSelectionContextValue {
   selectedSession: Session | null
+  selectedSessionId: string | null
   selectedWorkstream: SessionGroup | null
   selectSession: (id: string) => void
   selectWorkstream: (name: string) => void
@@ -109,12 +110,13 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
   const selectionValue = useMemo<SessionSelectionContextValue>(() => ({
     selectedSession: s.selectedSession,
+    selectedSessionId: s.selectedSessionId,
     selectedWorkstream: s.selectedWorkstream,
     selectSession: s.selectSession,
     selectWorkstream: s.selectWorkstream,
     clearSelection: s.clearSelection,
   }), [
-    s.selectedSession, s.selectedWorkstream,
+    s.selectedSession, s.selectedSessionId, s.selectedWorkstream,
     s.selectSession, s.selectWorkstream, s.clearSelection,
   ])
 

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -28,6 +28,7 @@ export interface UseSessionsResult {
   sessions: SessionSummary[]
   allSessions: SessionSummary[]
   selectedSession: Session | null
+  selectedSessionId: string | null
   selectedWorkstream: SessionGroup | null
   statusFilter: SessionStatus | 'all'
   sourceFilter: 'copilot' | 'claude' | 'all'
@@ -543,6 +544,7 @@ export function useSessions(): UseSessionsResult {
     sessions,
     allSessions: sessionsWithNames,
     selectedSession,
+    selectedSessionId,
     selectedWorkstream,
     statusFilter,
     sourceFilter,

--- a/src/hooks/useSourceStatus.ts
+++ b/src/hooks/useSourceStatus.ts
@@ -1,0 +1,70 @@
+import { useState, useEffect, useRef } from 'react'
+
+export interface SourceStatus {
+  copilot: {
+    available: boolean
+    sqliteAvailable: boolean
+    filesystemAvailable: boolean
+    sessionStateDir: string
+  }
+  claude: {
+    available: boolean
+    claudeDir: string
+  }
+}
+
+interface UseSourceStatusResult {
+  sources: SourceStatus | null
+  isLoading: boolean
+}
+
+// Module-level cache — survives re-mounts, fetched once per page session
+let cachedStatus: SourceStatus | null = null
+let fetchPromise: Promise<SourceStatus | null> | null = null
+
+async function fetchSourceStatus(): Promise<SourceStatus | null> {
+  try {
+    const response = await fetch('/api/sessions/status')
+    if (response.status === 404) return null
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+export function useSourceStatus(): UseSourceStatusResult {
+  const [sources, setSources] = useState<SourceStatus | null>(cachedStatus)
+  const [isLoading, setIsLoading] = useState(cachedStatus === null)
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+
+    if (cachedStatus !== null) {
+      setSources(cachedStatus)
+      setIsLoading(false)
+      return
+    }
+
+    // Deduplicate concurrent calls
+    if (!fetchPromise) {
+      fetchPromise = fetchSourceStatus()
+    }
+
+    fetchPromise.then((result) => {
+      cachedStatus = result
+      fetchPromise = null
+      if (mounted.current) {
+        setSources(result)
+        setIsLoading(false)
+      }
+    })
+
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  return { sources, isLoading }
+}

--- a/src/hooks/useSourceStatus.ts
+++ b/src/hooks/useSourceStatus.ts
@@ -41,11 +41,8 @@ export function useSourceStatus(): UseSourceStatusResult {
   useEffect(() => {
     mounted.current = true
 
-    if (cachedStatus !== null) {
-      setSources(cachedStatus)
-      setIsLoading(false)
-      return
-    }
+    // Already initialized from cache via useState — skip fetch
+    if (cachedStatus !== null) return
 
     // Deduplicate concurrent calls
     if (!fetchPromise) {


### PR DESCRIPTION
## Summary

Fixes session detail 404 when SQLite DB absent + adds fresh-user welcome experience.

### Backend
- Filesystem fallback in CopilotSessionSource — discovers sessions from session-state dirs when SQLite is absent
- readEventsHead() — reads first 64KB of events.jsonl for session metadata
- SessionMappingContext — injects event-derived metadata into mapToSession()
- Provider routing — mapSessionById routes through CopilotSessionSource
- GET /api/sessions/status — new endpoint for source availability

### Frontend
- WelcomeCard component with source detection status
- useSourceStatus hook — fetches status endpoint, caches per session
- KanbanBoard integration — WelcomeCard renders in default view when empty
- Graceful 404 in SessionDetail — friendly message instead of blank pane

### Tests
- 46 new tests across 4 files (321 total, all passing, tsc clean)
