### PR TITLE
feat: per-session ADO context, inline agent stats, waiting popover

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -38,6 +38,8 @@ export interface RuntimeConfig {
   maxTimelineEvents: number;
   adoOrganization: string;
   adoProject: string;
+  adoRepository: string;
+  adoFilterByCreator: boolean;
   claudeDir: string;
   sessionSources: SessionSourceOption;
   launchCommands: LaunchCommands;
@@ -101,12 +103,14 @@ const ADO_CONFIG_PATH = path.join(ADO_CONFIG_DIR, 'ado-config.json');
 interface AdoDiskConfig {
   organization: string;
   project: string;
+  repository?: string;
+  filterByCreator?: boolean;
 }
 
-export function loadAdoConfigFromDisk(): { organization: string | null; project: string | null } {
+export function loadAdoConfigFromDisk(): { organization: string | null; project: string | null; repository: string | null; filterByCreator: boolean | null } {
   try {
     if (!fs.existsSync(ADO_CONFIG_PATH)) {
-      return { organization: null, project: null };
+      return { organization: null, project: null, repository: null, filterByCreator: null };
     }
     const raw = fs.readFileSync(ADO_CONFIG_PATH, 'utf-8');
     const parsed: unknown = JSON.parse(raw);
@@ -118,23 +122,25 @@ export function loadAdoConfigFromDisk(): { organization: string | null; project:
       const obj = parsed as Record<string, unknown>;
       const organization = typeof obj.organization === 'string' ? obj.organization : null;
       const project = typeof obj.project === 'string' ? obj.project : null;
+      const repository = typeof obj.repository === 'string' ? obj.repository : null;
+      const filterByCreator = typeof obj.filterByCreator === 'boolean' ? obj.filterByCreator : null;
       if (organization || project) {
         console.log(`[ADO] Loaded config from ~/.rocinante/ado-config.json: org=${organization ?? ''}, project=${project ?? ''}`);
       }
-      return { organization, project };
+      return { organization, project, repository, filterByCreator };
     }
-    return { organization: null, project: null };
+    return { organization: null, project: null, repository: null, filterByCreator: null };
   } catch {
-    return { organization: null, project: null };
+    return { organization: null, project: null, repository: null, filterByCreator: null };
   }
 }
 
-export function saveAdoConfigToDisk(organization: string, project: string): void {
+export function saveAdoConfigToDisk(organization: string, project: string, repository: string, filterByCreator: boolean): void {
   try {
     if (!fs.existsSync(ADO_CONFIG_DIR)) {
       fs.mkdirSync(ADO_CONFIG_DIR, { recursive: true });
     }
-    const data: AdoDiskConfig = { organization, project };
+    const data: AdoDiskConfig = { organization, project, repository, filterByCreator };
     fs.writeFileSync(ADO_CONFIG_PATH, JSON.stringify(data, null, 2) + '\n', 'utf-8');
   } catch (err) {
     console.error('[ADO] Failed to save config to disk:', err instanceof Error ? err.message : String(err));
@@ -156,6 +162,8 @@ const runtimeConfig: RuntimeConfig = {
   maxTimelineEvents: parseInt(process.env.MAX_TIMELINE_EVENTS || '100', 10),
   adoOrganization: process.env.ADO_ORG || diskConfig.organization || '',
   adoProject: process.env.ADO_PROJECT || diskConfig.project || '',
+  adoRepository: process.env.ADO_REPOSITORY || diskConfig.repository || '',
+  adoFilterByCreator: process.env.ADO_FILTER_BY_CREATOR === 'true' || diskConfig.filterByCreator || false,
   claudeDir: process.env.CLAUDE_DIR || path.join(os.homedir(), '.claude'),
   sessionSources: parseSessionSources(process.env.SESSION_SOURCES),
   launchCommands: { ...DEFAULT_LAUNCH_COMMANDS, ...diskLaunchCommands },
@@ -168,7 +176,9 @@ export function getConfig(): Readonly<RuntimeConfig> {
 export function updateConfig(partial: Partial<RuntimeConfig>): RuntimeConfig {
   const adoChanged =
     ('adoOrganization' in partial && partial.adoOrganization !== runtimeConfig.adoOrganization) ||
-    ('adoProject' in partial && partial.adoProject !== runtimeConfig.adoProject);
+    ('adoProject' in partial && partial.adoProject !== runtimeConfig.adoProject) ||
+    ('adoRepository' in partial && partial.adoRepository !== runtimeConfig.adoRepository) ||
+    ('adoFilterByCreator' in partial && partial.adoFilterByCreator !== runtimeConfig.adoFilterByCreator);
 
   const launchCommandsChanged =
     'launchCommands' in partial && partial.launchCommands !== undefined;
@@ -176,7 +186,7 @@ export function updateConfig(partial: Partial<RuntimeConfig>): RuntimeConfig {
   Object.assign(runtimeConfig, partial);
 
   if (adoChanged) {
-    saveAdoConfigToDisk(runtimeConfig.adoOrganization, runtimeConfig.adoProject);
+    saveAdoConfigToDisk(runtimeConfig.adoOrganization, runtimeConfig.adoProject, runtimeConfig.adoRepository, runtimeConfig.adoFilterByCreator);
   }
 
   if (launchCommandsChanged) {

--- a/server/routes/__tests__/adoSessionDeliverables.test.ts
+++ b/server/routes/__tests__/adoSessionDeliverables.test.ts
@@ -21,6 +21,7 @@ const mockMcpGetWorkItemsBatch = vi.fn();
 
 const mockGetPullRequestsByBranches = vi.fn();
 const mockGetWorkItemsForPullRequest = vi.fn();
+const mockGetAuthenticatedUserDisplayName = vi.fn();
 
 vi.mock('../../services/adoMcpClient.js', () => ({
   mcpListPullRequests: (...args: unknown[]) => mockMcpListPullRequests(...args),
@@ -31,6 +32,7 @@ vi.mock('../../services/adoMcpClient.js', () => ({
 vi.mock('../../services/adoClient.js', () => ({
   getPullRequestsByBranches: (...args: unknown[]) => mockGetPullRequestsByBranches(...args),
   getWorkItemsForPullRequest: (...args: unknown[]) => mockGetWorkItemsForPullRequest(...args),
+  getAuthenticatedUserDisplayName: (...args: unknown[]) => mockGetAuthenticatedUserDisplayName(...args),
   getWorkItems: vi.fn(),
   testAdoConnection: vi.fn(),
   clearAdoCache: vi.fn(),
@@ -39,11 +41,15 @@ vi.mock('../../services/adoClient.js', () => ({
 
 let mockAdoConfigured = true;
 let mockAdoProject = 'TestProject';
+let mockAdoRepository = '';
+let mockAdoFilterByCreator = false;
 
 vi.mock('../../config.js', () => ({
   getConfig: vi.fn(() => ({
     adoOrganization: 'TestOrg',
     adoProject: mockAdoProject,
+    adoRepository: mockAdoRepository,
+    adoFilterByCreator: mockAdoFilterByCreator,
     cacheTtlMs: 10000,
     sessionStateDir: '/mock',
     staleThresholdMs: 300000,
@@ -123,6 +129,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockAdoConfigured = true;
   mockAdoProject = 'TestProject';
+  mockAdoRepository = '';
+  mockAdoFilterByCreator = false;
 });
 
 afterEach(() => {
@@ -234,7 +242,7 @@ describe('GET /api/ado/session-deliverables', () => {
       const body = res.body as { pullRequests: unknown[]; workItems: unknown[] };
       expect(body.pullRequests).toHaveLength(1);
       expect(body.workItems).toHaveLength(1);
-      expect(mockGetPullRequestsByBranches).toHaveBeenCalledWith(['feature/y']);
+      expect(mockGetPullRequestsByBranches).toHaveBeenCalledWith(['feature/y'], undefined, 'TestOrg', 'TestProject');
     });
 
     it('REST path deduplicates work items across PRs', async () => {
@@ -275,6 +283,165 @@ describe('GET /api/ado/session-deliverables', () => {
 
       const res = await callSessionDeliverables({ branch: 'feature/x' });
       expect(res.statusCode).toBe(500);
+    });
+  });
+
+  describe('repository scoping', () => {
+    it('passes repository query param to MCP when provided', async () => {
+      mockMcpListPullRequests.mockResolvedValue([]);
+
+      await callSessionDeliverables({ branch: 'feature/x', repository: 'my-repo' });
+
+      expect(mockMcpListPullRequests).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryId: 'my-repo' }),
+      );
+    });
+
+    it('passes config adoRepository to MCP as fallback', async () => {
+      mockAdoRepository = 'config-repo';
+      mockMcpListPullRequests.mockResolvedValue([]);
+
+      await callSessionDeliverables({ branch: 'feature/x' });
+
+      expect(mockMcpListPullRequests).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryId: 'config-repo' }),
+      );
+    });
+
+    it('passes repository query param to REST when MCP fails', async () => {
+      mockMcpListPullRequests.mockRejectedValue(new Error('MCP down'));
+      mockGetPullRequestsByBranches.mockResolvedValue([]);
+
+      await callSessionDeliverables({ branch: 'feature/x', repository: 'my-repo' });
+
+      expect(mockGetPullRequestsByBranches).toHaveBeenCalledWith(['feature/x'], 'my-repo', 'TestOrg', 'TestProject');
+    });
+
+    it('no repository filter when neither query param nor config is set', async () => {
+      mockMcpListPullRequests.mockResolvedValue([]);
+
+      await callSessionDeliverables({ branch: 'feature/x' });
+
+      const opts = mockMcpListPullRequests.mock.calls[0][0];
+      expect(opts.repositoryId).toBeUndefined();
+    });
+
+    it('query param repository overrides config repository', async () => {
+      mockAdoRepository = 'config-repo';
+      mockMcpListPullRequests.mockResolvedValue([]);
+
+      await callSessionDeliverables({ branch: 'feature/x', repository: 'override-repo' });
+
+      expect(mockMcpListPullRequests).toHaveBeenCalledWith(
+        expect.objectContaining({ repositoryId: 'override-repo' }),
+      );
+    });
+  });
+
+  describe('per-session org/project overrides', () => {
+    it('passes per-session organization and project to MCP when query params provided', async () => {
+      mockMcpListPullRequests.mockResolvedValue([]);
+
+      await callSessionDeliverables({
+        branch: 'users/gaburns/my-feature',
+        organization: 'microsoft',
+        project: 'DefenderCommon',
+        repository: 'MTP.SovClouds.AdoSidecarExtension',
+      });
+
+      expect(mockMcpListPullRequests).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project: 'DefenderCommon',
+          repositoryId: 'MTP.SovClouds.AdoSidecarExtension',
+        }),
+      );
+    });
+
+    it('passes per-session organization and project to REST fallback', async () => {
+      mockMcpListPullRequests.mockRejectedValue(new Error('MCP down'));
+      mockGetPullRequestsByBranches.mockResolvedValue([]);
+
+      await callSessionDeliverables({
+        branch: 'users/gaburns/my-feature',
+        organization: 'microsoft',
+        project: 'DefenderCommon',
+        repository: 'MTP.SovClouds.AdoSidecarExtension',
+      });
+
+      expect(mockGetPullRequestsByBranches).toHaveBeenCalledWith(
+        ['users/gaburns/my-feature'],
+        'MTP.SovClouds.AdoSidecarExtension',
+        'microsoft',
+        'DefenderCommon',
+      );
+    });
+
+    it('falls back to global config when no per-session params provided', async () => {
+      mockMcpListPullRequests.mockRejectedValue(new Error('MCP down'));
+      mockGetPullRequestsByBranches.mockResolvedValue([]);
+
+      await callSessionDeliverables({ branch: 'feature/x' });
+
+      expect(mockGetPullRequestsByBranches).toHaveBeenCalledWith(
+        ['feature/x'],
+        undefined,
+        'TestOrg',
+        'TestProject',
+      );
+    });
+  });
+
+  describe('creator filtering', () => {
+    it('filters PRs by creator when adoFilterByCreator is true', async () => {
+      mockAdoFilterByCreator = true;
+      mockGetAuthenticatedUserDisplayName.mockResolvedValue('Alice');
+
+      const pr1 = makePr(101, 'feature/x', 'repo-1');
+      pr1.createdBy = 'Alice';
+      const pr2 = makePr(102, 'feature/x', 'repo-1');
+      pr2.createdBy = 'Bob';
+
+      mockMcpListPullRequests.mockResolvedValue([pr1, pr2]);
+      mockMcpGetPullRequest
+        .mockResolvedValueOnce({ pr: pr1, workItemIds: [] })
+        .mockResolvedValueOnce({ pr: pr2, workItemIds: [] });
+
+      const res = await callSessionDeliverables({ branch: 'feature/x' });
+      const body = res.body as { pullRequests: Array<{ createdBy: string }> };
+      expect(body.pullRequests).toHaveLength(1);
+      expect(body.pullRequests[0].createdBy).toBe('Alice');
+    });
+
+    it('does not filter PRs when adoFilterByCreator is false', async () => {
+      mockAdoFilterByCreator = false;
+
+      const pr1 = makePr(101, 'feature/x', 'repo-1');
+      pr1.createdBy = 'Alice';
+      const pr2 = makePr(102, 'feature/x', 'repo-1');
+      pr2.createdBy = 'Bob';
+
+      mockMcpListPullRequests.mockResolvedValue([pr1, pr2]);
+      mockMcpGetPullRequest
+        .mockResolvedValueOnce({ pr: pr1, workItemIds: [] })
+        .mockResolvedValueOnce({ pr: pr2, workItemIds: [] });
+
+      const res = await callSessionDeliverables({ branch: 'feature/x' });
+      const body = res.body as { pullRequests: unknown[] };
+      expect(body.pullRequests).toHaveLength(2);
+      expect(mockGetAuthenticatedUserDisplayName).not.toHaveBeenCalled();
+    });
+
+    it('returns all PRs when creator filter is on but user name cannot be resolved', async () => {
+      mockAdoFilterByCreator = true;
+      mockGetAuthenticatedUserDisplayName.mockResolvedValue(null);
+
+      const pr1 = makePr(101, 'feature/x', 'repo-1');
+      mockMcpListPullRequests.mockResolvedValue([pr1]);
+      mockMcpGetPullRequest.mockResolvedValue({ pr: pr1, workItemIds: [] });
+
+      const res = await callSessionDeliverables({ branch: 'feature/x' });
+      const body = res.body as { pullRequests: unknown[] };
+      expect(body.pullRequests).toHaveLength(1);
     });
   });
 });

--- a/server/routes/ado.ts
+++ b/server/routes/ado.ts
@@ -3,6 +3,7 @@ import { getConfig, isAdoConfigured, updateConfig } from '../config.js';
 import {
   clearAdoCache,
   clearTokenCache,
+  getAuthenticatedUserDisplayName,
   getPullRequestsByBranches,
   getWorkItems,
   getWorkItemsForPullRequest,
@@ -27,6 +28,8 @@ adoRouter.get('/ado/status', (req, res) => {
     configured: isAdoConfigured(),
     organization: config.adoOrganization,
     project: config.adoProject,
+    repository: config.adoRepository,
+    filterByCreator: config.adoFilterByCreator,
   });
 });
 
@@ -86,8 +89,12 @@ adoRouter.get('/ado/pullrequests', async (req, res) => {
     return;
   }
 
+  const repositoryParam = typeof req.query.repository === 'string' ? req.query.repository.trim() : '';
+  const config = getConfig();
+  const repository = repositoryParam || config.adoRepository || '';
+
   try {
-    const pullRequests = await getPullRequestsByBranches(branches);
+    const pullRequests = await getPullRequestsByBranches(branches, repository || undefined);
     res.json(pullRequests);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -103,7 +110,7 @@ adoRouter.patch('/ado/config', (req, res) => {
     return;
   }
 
-  const allowedKeys = new Set(['organization', 'project']);
+  const allowedKeys = new Set(['organization', 'project', 'repository', 'filterByCreator']);
   for (const key of Object.keys(body)) {
     if (!allowedKeys.has(key)) {
       res.status(400).json({ error: `Unknown config field: ${key}` });
@@ -114,6 +121,8 @@ adoRouter.patch('/ado/config', (req, res) => {
   const patch: {
     adoOrganization?: string;
     adoProject?: string;
+    adoRepository?: string;
+    adoFilterByCreator?: boolean;
   } = {};
 
   if ('organization' in body) {
@@ -132,6 +141,22 @@ adoRouter.patch('/ado/config', (req, res) => {
     patch.adoProject = body.project.trim();
   }
 
+  if ('repository' in body) {
+    if (typeof body.repository !== 'string') {
+      res.status(400).json({ error: 'repository must be a string.' });
+      return;
+    }
+    patch.adoRepository = body.repository.trim();
+  }
+
+  if ('filterByCreator' in body) {
+    if (typeof body.filterByCreator !== 'boolean') {
+      res.status(400).json({ error: 'filterByCreator must be a boolean.' });
+      return;
+    }
+    patch.adoFilterByCreator = body.filterByCreator;
+  }
+
   const updated = updateConfig(patch);
   clearAdoCache();
   clearTokenCache();
@@ -139,6 +164,8 @@ adoRouter.patch('/ado/config', (req, res) => {
     configured: isAdoConfigured(),
     organization: updated.adoOrganization,
     project: updated.adoProject,
+    repository: updated.adoRepository,
+    filterByCreator: updated.adoFilterByCreator,
   });
 });
 
@@ -157,39 +184,64 @@ adoRouter.get('/ado/session-deliverables', async (req, res) => {
   }
 
   const config = getConfig();
-  const project = config.adoProject;
   const trimmedBranch = branch.trim();
+
+  // Per-session overrides: query param → global config → error/empty
+  const orgParam = typeof req.query.organization === 'string' ? req.query.organization.trim() : '';
+  const projParam = typeof req.query.project === 'string' ? req.query.project.trim() : '';
+  const organization = orgParam || config.adoOrganization;
+  const project = projParam || config.adoProject;
+
+  // Resolve repository: query param → config → empty (no filter)
+  const repositoryParam = typeof req.query.repository === 'string' ? req.query.repository.trim() : '';
+  const repository = repositoryParam || config.adoRepository || '';
 
   // Try MCP path first, fall back to direct REST on failure
   console.log(`[ADO] ${new Date().toISOString()} trying MCP path...`);
+  let result: { pullRequests: import('../../src/types/ado.js').AdoPullRequest[]; workItems: import('../../src/types/ado.js').AdoWorkItem[] } | null = null;
+
   try {
-    const result = await fetchDeliverablesViaMcp(project, trimmedBranch);
+    result = await fetchDeliverablesViaMcp(project, trimmedBranch, repository);
     console.log(`[ADO] ${new Date().toISOString()} MCP path succeeded:`, result.pullRequests.length, 'PRs,', result.workItems.length, 'WIs');
-    res.json(result);
-    return;
   } catch (err) {
     console.log(`[ADO] ${new Date().toISOString()} MCP path failed:`, err instanceof Error ? err.message : String(err));
   }
 
-  console.log(`[ADO] ${new Date().toISOString()} trying REST path...`);
-  try {
-    const result = await fetchDeliverablesViaRest(trimmedBranch);
-    console.log(`[ADO] ${new Date().toISOString()} REST path succeeded:`, result.pullRequests.length, 'PRs,', result.workItems.length, 'WIs');
-    res.json(result);
-  } catch (error) {
-    console.log(`[ADO] ${new Date().toISOString()} REST path failed:`, error instanceof Error ? error.message : String(error));
-    const message = error instanceof Error ? error.message : String(error);
-    const status = isLikelyUpstreamError(error) ? 502 : 500;
-    res.status(status).json({ error: message });
+  if (!result) {
+    console.log(`[ADO] ${new Date().toISOString()} trying REST path...`);
+    try {
+      result = await fetchDeliverablesViaRest(trimmedBranch, repository, organization, project);
+      console.log(`[ADO] ${new Date().toISOString()} REST path succeeded:`, result.pullRequests.length, 'PRs,', result.workItems.length, 'WIs');
+    } catch (error) {
+      console.log(`[ADO] ${new Date().toISOString()} REST path failed:`, error instanceof Error ? error.message : String(error));
+      const message = error instanceof Error ? error.message : String(error);
+      const status = isLikelyUpstreamError(error) ? 502 : 500;
+      res.status(status).json({ error: message });
+      return;
+    }
   }
+
+  // Apply creator filter if enabled
+  if (config.adoFilterByCreator) {
+    const userName = await getAuthenticatedUserDisplayName();
+    if (userName) {
+      result.pullRequests = result.pullRequests.filter(pr => pr.createdBy === userName);
+    }
+  }
+
+  res.json(result);
 });
 
-async function fetchDeliverablesViaMcp(project: string, branch: string) {
-  const pullRequests = await mcpListPullRequests({
+async function fetchDeliverablesViaMcp(project: string, branch: string, repository: string) {
+  const opts: Parameters<typeof mcpListPullRequests>[0] = {
     project,
     sourceRefName: `refs/heads/${branch}`,
     status: 'All',
-  });
+  };
+  if (repository) {
+    opts.repositoryId = repository;
+  }
+  const pullRequests = await mcpListPullRequests(opts);
 
   // For each PR with a repository, fetch linked work item IDs
   const workItemIdResults = await Promise.allSettled(
@@ -221,13 +273,13 @@ async function fetchDeliverablesViaMcp(project: string, branch: string) {
   return { pullRequests, workItems };
 }
 
-async function fetchDeliverablesViaRest(branch: string) {
-  const pullRequests = await getPullRequestsByBranches([branch]);
+async function fetchDeliverablesViaRest(branch: string, repository: string, organization: string, project: string) {
+  const pullRequests = await getPullRequestsByBranches([branch], repository || undefined, organization, project);
 
   const workItemResults = await Promise.allSettled(
     pullRequests
       .filter((pr) => pr.repositoryId)
-      .map((pr) => getWorkItemsForPullRequest(pr.repositoryId!, pr.id)),
+      .map((pr) => getWorkItemsForPullRequest(pr.repositoryId!, pr.id, organization, project)),
   );
 
   const workItemMap = new Map<number, import('../../src/types/ado.js').AdoWorkItem>();

--- a/server/routes/ado.ts
+++ b/server/routes/ado.ts
@@ -201,7 +201,7 @@ adoRouter.get('/ado/session-deliverables', async (req, res) => {
   let result: { pullRequests: import('../../src/types/ado.js').AdoPullRequest[]; workItems: import('../../src/types/ado.js').AdoWorkItem[] } | null = null;
 
   try {
-    result = await fetchDeliverablesViaMcp(project, trimmedBranch, repository);
+    result = await fetchDeliverablesViaMcp(project, trimmedBranch, repository, organization);
     console.log(`[ADO] ${new Date().toISOString()} MCP path succeeded:`, result.pullRequests.length, 'PRs,', result.workItems.length, 'WIs');
   } catch (err) {
     console.log(`[ADO] ${new Date().toISOString()} MCP path failed:`, err instanceof Error ? err.message : String(err));
@@ -232,11 +232,12 @@ adoRouter.get('/ado/session-deliverables', async (req, res) => {
   res.json(result);
 });
 
-async function fetchDeliverablesViaMcp(project: string, branch: string, repository: string) {
+async function fetchDeliverablesViaMcp(project: string, branch: string, repository: string, organization?: string) {
   const opts: Parameters<typeof mcpListPullRequests>[0] = {
     project,
     sourceRefName: `refs/heads/${branch}`,
     status: 'All',
+    organization,
   };
   if (repository) {
     opts.repositoryId = repository;
@@ -253,6 +254,7 @@ async function fetchDeliverablesViaMcp(project: string, branch: string, reposito
           repositoryId: pr.repositoryId!,
           pullRequestId: pr.id,
           includeWorkItemRefs: true,
+          organization,
         }),
       ),
   );

--- a/server/services/adoClient.ts
+++ b/server/services/adoClient.ts
@@ -228,13 +228,15 @@ function normalizeBranch(refName: string | undefined): string {
   return refName.replace(/^refs\/heads\//, '');
 }
 
-function buildPrUrl(webUrl: string | undefined, repoName: string | undefined, prId: number): string {
+function buildPrUrl(webUrl: string | undefined, repoName: string | undefined, prId: number, organization?: string, project?: string): string {
   if (webUrl) {
     return `${webUrl}/pullrequest/${prId}`;
   }
   const config = getConfig();
+  const org = organization || config.adoOrganization;
+  const proj = project || config.adoProject;
   const repoSegment = repoName ? `${repoName}/` : '';
-  return `https://dev.azure.com/${config.adoOrganization}/${config.adoProject}/_git/${repoSegment}pullrequest/${prId}`;
+  return `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(proj)}/_git/${repoSegment}pullrequest/${prId}`;
 }
 
 export async function getPullRequestsByBranches(
@@ -291,7 +293,7 @@ export async function getPullRequestsByBranches(
           displayName: reviewer.displayName ?? '',
           vote: typeof reviewer.vote === 'number' ? reviewer.vote : 0,
         })),
-        url: buildPrUrl(pr.repository?.webUrl, pr.repository?.name, pr.pullRequestId),
+        url: buildPrUrl(pr.repository?.webUrl, pr.repository?.name, pr.pullRequestId, organization, project),
       });
     }
   }

--- a/server/services/adoClient.ts
+++ b/server/services/adoClient.ts
@@ -4,6 +4,7 @@ import type { AdoPullRequest, AdoWorkItem } from '../../src/types/ado.js';
 const cache = new Map<string, { data: unknown; fetchedAt: number }>();
 const CACHE_TTL = 300_000;
 let cachedToken: { token: string; expiresAt: number } | null = null;
+let cachedUserDisplayName: string | null = null;
 
 class AdoApiError extends Error {
   status?: number;
@@ -75,12 +76,20 @@ async function getAdoToken(): Promise<string> {
   }
 }
 
-async function adoFetch<T>(path: string, scope: AdoApiScope = 'project'): Promise<T> {
+export async function adoFetch<T>(path: string, scope: AdoApiScope = 'project'): Promise<T> {
   if (!isAdoConfigured()) {
     throw new AdoApiError('Azure DevOps is not configured.');
   }
 
   const requestUrl = buildAdoApiUrl(path, scope);
+  return adoFetchUrl<T>(requestUrl);
+}
+
+/**
+ * Fetch from an arbitrary ADO URL (for per-session org/project overrides).
+ * Uses the same token acquisition as adoFetch.
+ */
+export async function adoFetchUrl<T>(requestUrl: string): Promise<T> {
   const token = await getAdoToken();
 
   let response: Response;
@@ -228,17 +237,33 @@ function buildPrUrl(webUrl: string | undefined, repoName: string | undefined, pr
   return `https://dev.azure.com/${config.adoOrganization}/${config.adoProject}/_git/${repoSegment}pullrequest/${prId}`;
 }
 
-export async function getPullRequestsByBranches(branches: string[]): Promise<AdoPullRequest[]> {
+export async function getPullRequestsByBranches(
+  branches: string[],
+  repository?: string,
+  organization?: string,
+  project?: string,
+): Promise<AdoPullRequest[]> {
   if (branches.length === 0) {
     return [];
   }
 
   const uniqueBranches = Array.from(new Set(branches));
 
+  // When per-session org/project are provided, build full URLs directly
+  const useCustomContext = !!(organization && project);
+
   const settled = await Promise.allSettled(
-    uniqueBranches.map((branch) => cachedFetch<PullRequestResponse>(
-      `git/pullrequests?searchCriteria.sourceRefName=refs/heads/${branch}&searchCriteria.status=all&api-version=7.1`,
-    )),
+    uniqueBranches.map((branch) => {
+      const apiPath = repository
+        ? `git/repositories/${encodeURIComponent(repository)}/pullrequests?searchCriteria.sourceRefName=refs/heads/${branch}&searchCriteria.status=all&api-version=7.1`
+        : `git/pullrequests?searchCriteria.sourceRefName=refs/heads/${branch}&searchCriteria.status=all&api-version=7.1`;
+
+      if (useCustomContext) {
+        const fullUrl = `https://dev.azure.com/${encodeURIComponent(organization!)}/${encodeURIComponent(project!)}/_apis/${apiPath}`;
+        return adoFetchUrl<PullRequestResponse>(fullUrl);
+      }
+      return cachedFetch<PullRequestResponse>(apiPath);
+    }),
   );
 
   const deduped = new Map<number, AdoPullRequest>();
@@ -281,12 +306,22 @@ type PullRequestWorkItemRefsResponse = {
   }>;
 };
 
-export async function getWorkItemsForPullRequest(repositoryId: string, prId: number): Promise<AdoWorkItem[]> {
-  const path = `git/repositories/${repositoryId}/pullRequests/${prId}/workitems?api-version=7.1`;
+export async function getWorkItemsForPullRequest(
+  repositoryId: string,
+  prId: number,
+  organization?: string,
+  project?: string,
+): Promise<AdoWorkItem[]> {
+  const apiPath = `git/repositories/${repositoryId}/pullRequests/${prId}/workitems?api-version=7.1`;
 
   let refs: PullRequestWorkItemRefsResponse;
   try {
-    refs = await cachedFetch<PullRequestWorkItemRefsResponse>(path);
+    if (organization && project) {
+      const fullUrl = `https://dev.azure.com/${encodeURIComponent(organization)}/${encodeURIComponent(project)}/_apis/${apiPath}`;
+      refs = await adoFetchUrl<PullRequestWorkItemRefsResponse>(fullUrl);
+    } else {
+      refs = await cachedFetch<PullRequestWorkItemRefsResponse>(apiPath);
+    }
   } catch (error) {
     if (error instanceof AdoApiError && error.status === 404) {
       return [];
@@ -382,9 +417,25 @@ export async function testAdoConnection(): Promise<AdoConnectionTestResult> {
 
 export function clearAdoCache(): void {
   cache.clear();
+  cachedUserDisplayName = null;
 }
 
 export function clearTokenCache(): void {
   cachedToken = null;
+  cachedUserDisplayName = null;
+}
+
+export async function getAuthenticatedUserDisplayName(): Promise<string | null> {
+  if (cachedUserDisplayName) return cachedUserDisplayName;
+  try {
+    const data = await adoFetch<{ authenticatedUser?: { providerDisplayName?: string } }>(
+      'connectionData?api-version=7.1',
+      'organization',
+    );
+    cachedUserDisplayName = data?.authenticatedUser?.providerDisplayName ?? null;
+    return cachedUserDisplayName;
+  } catch {
+    return null;
+  }
 }
 

--- a/server/services/adoMcpClient.ts
+++ b/server/services/adoMcpClient.ts
@@ -281,13 +281,15 @@ function normalizeBranch(refName: string | undefined): string {
   return refName.replace(/^refs\/heads\//, '');
 }
 
-function buildPrUrl(webUrl: string | undefined, repoName: string | undefined, prId: number): string {
+function buildPrUrl(webUrl: string | undefined, repoName: string | undefined, prId: number, organization?: string, project?: string): string {
   if (webUrl) {
     return `${webUrl}/pullrequest/${prId}`;
   }
   const config = getConfig();
+  const org = organization || config.adoOrganization;
+  const proj = project || config.adoProject;
   const repoSegment = repoName ? `${repoName}/` : '';
-  return `https://dev.azure.com/${config.adoOrganization}/${config.adoProject}/_git/${repoSegment}pullrequest/${prId}`;
+  return `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(proj)}/_git/${repoSegment}pullrequest/${prId}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +305,7 @@ export async function mcpListPullRequests(opts: {
   sourceRefName?: string;
   status?: string;
   top?: number;
+  organization?: string;
 }): Promise<AdoPullRequest[]> {
   const cacheKey = `listPRs:${JSON.stringify(opts)}`;
   const cached = getCached<AdoPullRequest[]>(cacheKey);
@@ -321,7 +324,7 @@ export async function mcpListPullRequests(opts: {
 
   const prs: AdoPullRequest[] = items
     .filter((item: Record<string, unknown>) => typeof item.pullRequestId === 'number')
-    .map((item: Record<string, unknown>) => mapPullRequest(item));
+    .map((item: Record<string, unknown>) => mapPullRequest(item, opts.organization, opts.project));
 
   setCache(cacheKey, prs);
   return prs;
@@ -335,6 +338,7 @@ export async function mcpGetPullRequest(opts: {
   repositoryId: string;
   pullRequestId: number;
   includeWorkItemRefs?: boolean;
+  organization?: string;
 }): Promise<{ pr: AdoPullRequest; workItemIds: number[] }> {
   const cacheKey = `getPR:${opts.repositoryId}:${opts.pullRequestId}:${opts.includeWorkItemRefs}`;
   const cached = getCached<{ pr: AdoPullRequest; workItemIds: number[] }>(cacheKey);
@@ -352,7 +356,7 @@ export async function mcpGetPullRequest(opts: {
   const raw = await callTool('get_pull_request_by_id', args);
   const data = isObj(raw) ? raw : {};
 
-  const pr = mapPullRequest(data);
+  const pr = mapPullRequest(data, opts.organization, opts.project);
   let workItemIds: number[] = [];
 
   if (opts.includeWorkItemRefs && Array.isArray(data.workItemRefs)) {
@@ -442,7 +446,7 @@ function isObj(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-function mapPullRequest(item: Record<string, unknown>): AdoPullRequest {
+function mapPullRequest(item: Record<string, unknown>, organization?: string, project?: string): AdoPullRequest {
   const repo = isObj(item.repository) ? item.repository : {};
   const createdBy = isObj(item.createdBy) ? item.createdBy : {};
   const reviewersRaw = Array.isArray(item.reviewers) ? item.reviewers : [];
@@ -464,6 +468,6 @@ function mapPullRequest(item: Record<string, unknown>): AdoPullRequest {
       displayName: (r.displayName as string) ?? '',
       vote: typeof r.vote === 'number' ? r.vote : 0,
     })),
-    url: buildPrUrl(repo.webUrl as string | undefined, repo.name as string | undefined, (item.pullRequestId as number) ?? 0),
+    url: buildPrUrl(repo.webUrl as string | undefined, repo.name as string | undefined, (item.pullRequestId as number) ?? 0, organization, project),
   };
 }

--- a/server/services/providers/__tests__/copilotSourceFilesystem.test.ts
+++ b/server/services/providers/__tests__/copilotSourceFilesystem.test.ts
@@ -58,11 +58,13 @@ vi.mock('../../eventTailReader.js', () => ({
 const mockMapToSession = vi.fn();
 const mockMapSessionSummary = vi.fn();
 const mockGetSessionCwd = vi.fn();
+const mockReadWorkspaceMetadata = vi.fn();
 
 vi.mock('../../sessionMapper.js', () => ({
   mapToSession: (...args: unknown[]) => mockMapToSession(...args),
   mapSessionSummary: (...args: unknown[]) => mockMapSessionSummary(...args),
   getSessionCwd: (...args: unknown[]) => mockGetSessionCwd(...args),
+  readWorkspaceMetadata: (...args: unknown[]) => mockReadWorkspaceMetadata(...args),
 }));
 
 const mockGetOrComputeSummary = vi.fn();
@@ -153,6 +155,7 @@ beforeEach(() => {
   mockReadEventsTail.mockReturnValue([]);
   mockReadEventsHead.mockReturnValue({ createdAt: null, firstUserMessage: null, turnCount: 0 });
   mockGetSessionCwd.mockReturnValue(null);
+  mockReadWorkspaceMetadata.mockReturnValue({ cwd: null, repository: null, branch: null, host_type: null });
 });
 
 afterEach(() => {
@@ -278,6 +281,33 @@ describe('CopilotSessionSource', () => {
         firstUserMessage: 'Create the feature',
         turnCount: 5,
       });
+    });
+
+    it('populates syntheticRow with workspace metadata when available', () => {
+      mockGetSessionById.mockReturnValue(null);
+      mockExistsSync.mockImplementation((p: string) => p === eventsFilePath('ws-session'));
+      mockReadEventsHead.mockReturnValue({
+        createdAt: '2026-06-01T12:00:00Z',
+        firstUserMessage: 'Fix the extension',
+        turnCount: 3,
+      });
+      mockReadWorkspaceMetadata.mockReturnValue({
+        cwd: '/repos/DefenderCommon',
+        repository: 'microsoft/DefenderCommon/MTP.SovClouds.AdoSidecarExtension',
+        branch: 'users/gaburns/integrate-band-extension',
+        host_type: 'ado',
+      });
+      mockMapToSession.mockReturnValue(makeSession('ws-session'));
+
+      const source = new CopilotSessionSource();
+      source.getSession('ws-session');
+
+      expect(mockMapToSession).toHaveBeenCalledTimes(1);
+      const [syntheticRow] = mockMapToSession.mock.calls[0];
+      expect(syntheticRow.repository).toBe('microsoft/DefenderCommon/MTP.SovClouds.AdoSidecarExtension');
+      expect(syntheticRow.branch).toBe('users/gaburns/integrate-band-extension');
+      expect(syntheticRow.host_type).toBe('ado');
+      expect(syntheticRow.cwd).toBe('/repos/DefenderCommon');
     });
 
     it('handles corrupt events.jsonl gracefully (readEventsHead returns defaults)', () => {

--- a/server/services/providers/copilotSource.ts
+++ b/server/services/providers/copilotSource.ts
@@ -11,7 +11,7 @@ import {
 } from '../sqliteReader.js';
 import { readEventsTail } from '../eventTailReader.js';
 import { readEventsHead } from '../eventTailReader.js';
-import { mapToSession, mapSessionSummary, getSessionCwd, type SessionMappingContext } from '../sessionMapper.js';
+import { mapToSession, mapSessionSummary, getSessionCwd, readWorkspaceMetadata, type SessionMappingContext } from '../sessionMapper.js';
 import { getOrCompute as getOrComputeSummary, evictStale as evictStaleSummaries } from '../sessionSummaryCache.js';
 import { sanitizeSessionId } from '../../utils/sanitize.js';
 
@@ -81,16 +81,17 @@ export class CopilotSessionSource implements SessionSource {
       const headData = readEventsHead(id);
       const tailEvents = readEventsTail(id);
 
-      const cwd = getSessionCwd(id, null);
+      const wsMeta = readWorkspaceMetadata(id);
+      const cwd = wsMeta.cwd ?? getSessionCwd(id, null);
       const now = new Date().toISOString();
 
       const syntheticRow: SqliteSession = {
         id,
         cwd,
-        repository: null,
-        branch: null,
+        repository: wsMeta.repository,
+        branch: wsMeta.branch,
         summary: null,
-        host_type: null,
+        host_type: wsMeta.host_type,
         created_at: headData.createdAt || now,
         updated_at: tailEvents.length > 0
           ? tailEvents[tailEvents.length - 1].timestamp

--- a/server/services/sessionMapper.ts
+++ b/server/services/sessionMapper.ts
@@ -37,6 +37,35 @@ export interface SessionMappingContext {
   turnCount?: number;
 }
 
+/* ── Workspace metadata (read from workspace.yaml) ────────────── */
+
+export interface WorkspaceMetadata {
+  cwd: string | null;
+  repository: string | null;
+  branch: string | null;
+  host_type: string | null;
+}
+
+export function readWorkspaceMetadata(sessionId: string): WorkspaceMetadata {
+  const result: WorkspaceMetadata = { cwd: null, repository: null, branch: null, host_type: null };
+  try {
+    const safeId = sanitizeSessionId(sessionId);
+    const config = getConfig();
+    const workspaceFile = path.join(config.sessionStateDir, safeId, 'workspace.yaml');
+    if (fs.existsSync(workspaceFile)) {
+      const content = fs.readFileSync(workspaceFile, 'utf-8');
+      const data = yaml.load(content) as Record<string, unknown>;
+      if (data) {
+        if (typeof data.cwd === 'string' && data.cwd.trim()) result.cwd = data.cwd;
+        if (typeof data.repository === 'string' && data.repository.trim()) result.repository = data.repository;
+        if (typeof data.branch === 'string' && data.branch.trim()) result.branch = data.branch;
+        if (typeof data.host_type === 'string' && data.host_type.trim()) result.host_type = data.host_type;
+      }
+    }
+  } catch { /* silent */ }
+  return result;
+}
+
 /* ── Git context fallback (branch + repository from cwd) ──────── */
 
 interface GitContext {
@@ -154,22 +183,8 @@ export function getSessionCwd(sessionId: string, sqlCwd: string | null): string 
     return sqlCwd;
   }
 
-  try {
-    const safeId = sanitizeSessionId(sessionId);
-    const config = getConfig();
-    const workspaceFile = path.join(config.sessionStateDir, safeId, 'workspace.yaml');
-    if (fs.existsSync(workspaceFile)) {
-      const content = fs.readFileSync(workspaceFile, 'utf-8');
-      const data = yaml.load(content) as Record<string, unknown>;
-      if (data && typeof data.cwd === 'string' && data.cwd.trim().length > 0) {
-        return data.cwd;
-      }
-    }
-  } catch {
-    // Silently fall back to null
-  }
-
-  return null;
+  const wsMeta = readWorkspaceMetadata(sessionId);
+  return wsMeta.cwd;
 }
 
 const MAX_ASSISTANT_UPDATES = 20;
@@ -268,6 +283,7 @@ export function mapToSession(sqlRow: SqliteSession, events: ParsedEvent[], ctx?:
   const assistantUpdates = extractAssistantUpdates(events);
   const compaction = countCompactionEvents(events);
   const resolvedCwd = getSessionCwd(sqlRow.id, sqlRow.cwd);
+  const wsMeta = readWorkspaceMetadata(sqlRow.id);
   const gitFallback = resolveGitContext(resolvedCwd);
   const isSquad = detectSquadSession(events);
   const squadCast = isSquad ? extractSquadCast(events) : undefined;
@@ -290,8 +306,8 @@ export function mapToSession(sqlRow: SqliteSession, events: ParsedEvent[], ctx?:
     waitingQuestion: derivedStatus.waitingQuestion,
     waitingChoices: derivedStatus.waitingChoices,
     cwd: resolvedCwd,
-    repository: sqlRow.repository ?? gitFallback.repository,
-    branch: sqlRow.branch ?? gitFallback.branch,
+    repository: sqlRow.repository ?? wsMeta.repository ?? gitFallback.repository,
+    branch: sqlRow.branch ?? wsMeta.branch ?? gitFallback.branch,
     errorDetails: derivedStatus.errorDetails,
     latestUserMessage,
     lastAssistantUpdate: assistantUpdates && assistantUpdates.length > 0
@@ -443,6 +459,7 @@ export function mapSessionSummary(
     : undefined;
   const compaction = countCompactionEvents(events);
   const resolvedCwd = getSessionCwd(sqlRow.id, sqlRow.cwd);
+  const wsMeta = readWorkspaceMetadata(sqlRow.id);
   const gitFallback = resolveGitContext(resolvedCwd);
   const isSquad = detectSquadSession(events);
 
@@ -460,8 +477,8 @@ export function mapSessionSummary(
     waitingQuestion: derivedStatus.waitingQuestion,
     waitingChoices: derivedStatus.waitingChoices,
     cwd: resolvedCwd,
-    repository: sqlRow.repository ?? gitFallback.repository,
-    branch: sqlRow.branch ?? gitFallback.branch,
+    repository: sqlRow.repository ?? wsMeta.repository ?? gitFallback.repository,
+    branch: sqlRow.branch ?? wsMeta.branch ?? gitFallback.branch,
     errorDetails: derivedStatus.errorDetails,
     latestUserMessage,
     lastAssistantUpdate,

--- a/src/components/common/StatusSummaryBar.tsx
+++ b/src/components/common/StatusSummaryBar.tsx
@@ -137,7 +137,8 @@ export default function StatusSummaryBar() {
                   {content}
 
                   {/* Popover — shown on hover */}
-                  <div className="absolute left-0 top-full mt-2 z-50 hidden group-hover:block min-w-[200px] max-w-[320px] rounded-lg border border-border-default bg-surface-secondary shadow-lg">
+                  <div className="absolute left-0 top-full z-50 hidden group-hover:block min-w-[200px] max-w-[320px] pt-2">
+                   <div className="rounded-lg border border-border-default bg-surface-secondary shadow-lg">
                     <div className="px-3 py-2 border-b border-border-default">
                       <span className="font-mono text-[11px] font-medium uppercase tracking-widest text-fg/60">
                         Waiting for input
@@ -156,6 +157,7 @@ export default function StatusSummaryBar() {
                         </button>
                       ))}
                     </div>
+                   </div>
                   </div>
                 </div>
               ) : (

--- a/src/components/common/StatusSummaryBar.tsx
+++ b/src/components/common/StatusSummaryBar.tsx
@@ -1,4 +1,4 @@
-import { useSessionData } from '../../context/SessionContext'
+import { useSessionData, useSessionSelection } from '../../context/SessionContext'
 import { getStatusTextClass, getStatusDotClass } from '../../utils/statusColors'
 
 /* ────────────────────────────────────────────────────────
@@ -26,8 +26,10 @@ interface StatusItem {
 }
 
 export default function StatusSummaryBar() {
-  const { statusCounts, archivedCount, getWorkstreamNames } = useSessionData()
+  const { statusCounts, archivedCount, getWorkstreamNames, sessions } = useSessionData()
+  const { selectSession } = useSessionSelection()
   const workstreamCount = getWorkstreamNames.length
+  const waitingSessions = sessions.filter(s => s.status === 'waiting')
 
   const items: StatusItem[] = [
     { status: 'active',    count: statusCounts.active,    label: 'Active'  },
@@ -80,16 +82,15 @@ export default function StatusSummaryBar() {
 
       {/* ── Per-status counts ───────────────────────── */}
       <span className="flex items-center gap-3">
-        {items.map((item, idx) => (
-          <span key={item.status} className="flex items-center gap-1.5">
-            {/* interpunct separator (skip before first) */}
-            {idx > 0 && (
-              <span aria-hidden="true" className="text-fg/15 -ml-1.5 mr-0">
-                ·
-              </span>
-            )}
+        {items.map((item, idx) => {
+          const isWaitingWithSessions = item.status === 'waiting' && waitingSessions.length > 0
 
-            {/* colored dot */}
+          const dot = isWaitingWithSessions ? (
+            <span className="relative flex h-1.5 w-1.5 shrink-0" aria-hidden="true">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-400 opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
+            </span>
+          ) : (
             <span
               aria-hidden="true"
               className={`
@@ -98,29 +99,71 @@ export default function StatusSummaryBar() {
                 ${item.count === 0 ? 'opacity-30' : 'opacity-100'}
               `}
             />
+          )
 
-            {/* count */}
-            <span
-              className={`
-                font-semibold tabular-nums
-                ${getStatusTextClass(item.status)}
-                ${item.count === 0 ? 'opacity-30' : 'opacity-100'}
-              `}
-            >
-              {item.count}
-            </span>
+          const content = (
+            <>
+              {dot}
+              <span
+                className={`
+                  font-semibold tabular-nums
+                  ${getStatusTextClass(item.status)}
+                  ${item.count === 0 ? 'opacity-30' : 'opacity-100'}
+                `}
+              >
+                {item.count}
+              </span>
+              <span
+                className={`
+                  text-fg/40
+                  ${item.count === 0 ? 'opacity-30' : 'opacity-100'}
+                `}
+              >
+                {item.label}
+              </span>
+            </>
+          )
 
-            {/* label */}
-            <span
-              className={`
-                text-fg/40
-                ${item.count === 0 ? 'opacity-30' : 'opacity-100'}
-              `}
-            >
-              {item.label}
+          return (
+            <span key={item.status} className="flex items-center gap-1.5">
+              {idx > 0 && (
+                <span aria-hidden="true" className="text-fg/15 -ml-1.5 mr-0">
+                  ·
+                </span>
+              )}
+
+              {isWaitingWithSessions ? (
+                <div className="group relative flex items-center gap-1.5 cursor-pointer">
+                  {content}
+
+                  {/* Popover — shown on hover */}
+                  <div className="absolute left-0 top-full mt-2 z-50 hidden group-hover:block min-w-[200px] max-w-[320px] rounded-lg border border-border-default bg-surface-secondary shadow-lg">
+                    <div className="px-3 py-2 border-b border-border-default">
+                      <span className="font-mono text-[11px] font-medium uppercase tracking-widest text-fg/60">
+                        Waiting for input
+                      </span>
+                    </div>
+                    <div className="py-1 max-h-[200px] overflow-y-auto">
+                      {waitingSessions.map(session => (
+                        <button
+                          key={session.id}
+                          type="button"
+                          onClick={() => selectSession(session.id)}
+                          className="w-full px-3 py-1.5 text-left font-mono text-xs text-fg/70 hover:bg-surface-hover hover:text-fg/90 truncate transition-colors"
+                          title={session.name}
+                        >
+                          {session.name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <>{content}</>
+              )}
             </span>
-          </span>
-        ))}
+          )
+        })}
         {archivedCount > 0 && (
           <>
             <span className="text-fg/15 mx-1">·</span>

--- a/src/components/sessions/SessionDetail.tsx
+++ b/src/components/sessions/SessionDetail.tsx
@@ -761,6 +761,31 @@ export default function SessionDetail() {
                 </span>
               </>
             )}
+            {/* Agent status inline */}
+            <span aria-hidden="true" className="text-fg/15">·</span>
+            <span>
+              Agents: {totalAgents}
+              {(() => {
+                const parts: React.ReactNode[] = [];
+                if (agentCounts.running > 0) parts.push(<span key="r" className={getStatusTextClass('running')}>{agentCounts.running} running</span>);
+                if (agentCounts.blocked > 0) parts.push(<span key="b" className={getStatusTextClass('blocked')}>{agentCounts.blocked} blocked</span>);
+                if (agentCounts.waiting > 0) parts.push(<span key="w" className={getStatusTextClass('waiting')}>{agentCounts.waiting} waiting</span>);
+
+                if (parts.length === 0) {
+                  return <span className="ml-0.5 text-green-400/70">✓</span>;
+                }
+
+                return (
+                  <span className="ml-1">
+                    ({parts.reduce<React.ReactNode[]>((acc, part, i) => {
+                      if (i > 0) acc.push(<span key={`c${i}`} className="text-fg/25">, </span>);
+                      acc.push(part);
+                      return acc;
+                    }, [])})
+                  </span>
+                );
+              })()}
+            </span>
           </div>
 
           {/* Workstream assignment */}

--- a/src/components/sessions/SessionDetail.tsx
+++ b/src/components/sessions/SessionDetail.tsx
@@ -13,7 +13,6 @@ import {
   countAgents,
 } from '../../utils/formatters';
 import {
-  getStatusDotClass,
   getStatusTextClass,
 } from '../../utils/statusColors';
 import { renderInlineMarkdown } from '../../utils/inlineMarkdown';
@@ -282,41 +281,6 @@ function deliverableWorkItemStateBadgeClasses(state: string): string {
 
 function deliverableShortBranch(ref: string): string {
   return ref.replace(/^refs\/heads\//, '');
-}
-
-/* ── Stat card (quick-stats grid item) ────────────────────────
- *  A compact, color-coded tile for a single agent-status count.
- *  Zero-count cards are dimmed so attention stays on what matters. */
-
-interface StatCardProps {
-  status: AgentStatus;
-  label: string;
-  count: number;
-}
-
-function StatCard({ status, label, count }: StatCardProps) {
-  return (
-    <div
-      className={`
-        rounded-lg bg-surface-secondary px-3 py-2
-        transition-opacity duration-150
-        ${count === 0 ? 'opacity-40' : ''}
-      `}
-    >
-      <div className="flex items-center gap-1.5">
-        <span
-          aria-hidden="true"
-          className={`size-1.5 shrink-0 rounded-full ${getStatusDotClass(status)}`}
-        />
-        <span
-          className={`text-lg font-semibold tabular-nums leading-none ${getStatusTextClass(status)}`}
-        >
-          {count}
-        </span>
-      </div>
-      <p className="mt-1 font-mono text-[11px] text-fg/40">{label}</p>
-    </div>
-  );
 }
 
 function ExpandablePrompt({ text }: { text: string }) {
@@ -1158,28 +1122,7 @@ export default function SessionDetail() {
           </section>
         )}
 
-        {/* ── 2 · Quick stats ────────────────────────────── */}
-        {panes.quickStats && (
-          <section className="space-y-2">
-            <div className="flex items-baseline gap-2">
-              <h3 className="font-mono text-[11px] font-medium uppercase tracking-widest text-fg/60">
-                Agents
-              </h3>
-              <span className="font-mono text-[11px] tabular-nums text-fg/20">
-                {totalAgents} total
-              </span>
-            </div>
-
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-              <StatCard status="running"   label="Running"   count={agentCounts.running} />
-              <StatCard status="blocked"   label="Blocked"   count={agentCounts.blocked} />
-              <StatCard status="waiting"   label="Waiting"   count={agentCounts.waiting} />
-              <StatCard status="completed" label="Completed" count={agentCounts.completed} />
-            </div>
-          </section>
-        )}
-
-        {panes.sessionPlan && (
+        {panes.sessionPlan&& (
           <PlanViewer key={session.id} sessionId={session.id} />
         )}
 

--- a/src/components/sessions/SessionDetail.tsx
+++ b/src/components/sessions/SessionDetail.tsx
@@ -6,6 +6,7 @@ import type { SubAgent, AgentStatus, ErrorDetail } from '../../types';
 import type { AdoPullRequest } from '../../types/ado';
 import { getAdoStatus } from '../../services/adoService';
 import { useSessionDeliverables } from '../../hooks/useSessionDeliverables';
+import type { AdoContext } from '../../hooks/useSessionDeliverables';
 import {
   formatRelativeTime,
   formatDuration,
@@ -63,6 +64,24 @@ import PlanViewer from './PlanViewer';
  * ──────────────────────────────────────────────────────────────── */
 
 /* ── Helpers ──────────────────────────────────────────────────── */
+
+/**
+ * Parse an ADO-format repository string (org/project/repo) into
+ * per-session org/project/repo context for the deliverables API.
+ * GitHub-format (owner/repo) is left as-is — only 3+ segment paths are split.
+ */
+function parseAdoRepository(repository: string | null | undefined): AdoContext {
+  if (!repository) return {};
+  const parts = repository.split('/');
+  if (parts.length >= 3) {
+    return {
+      organization: parts[0],
+      project: parts[1],
+      repository: parts.slice(2).join('/'),
+    };
+  }
+  return { repository };
+}
 
 /** Recursively tallies every agent in the tree by its status. */
 function countAgentsByStatus(agent: SubAgent): Record<AgentStatus, number> {
@@ -375,7 +394,8 @@ export default function SessionDetail() {
   }, []);
 
   // Session deliverables hook — must be called before early return (rules of hooks)
-  const deliverables = useSessionDeliverables(selectedSession?.branch, isAdoConfigured);
+  const adoContext = parseAdoRepository(selectedSession?.repository);
+  const deliverables = useSessionDeliverables(selectedSession?.branch, isAdoConfigured, adoContext);
   const deliverablesCount = deliverables.pullRequests.length + deliverables.workItems.length;
   const [deliverablesExpanded, setDeliverablesExpanded] = useState(true);
 

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -876,21 +876,6 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                   />
                 </FieldRow>
 
-                <FieldRow label="Quick Stats">
-                  <Toggle
-                    label="Show quick stats pane"
-                    checked={display.paneVisibility.quickStats}
-                    onChange={(v) =>
-                      updateDisplaySettings({
-                        paneVisibility: {
-                          ...settings.display.paneVisibility,
-                          quickStats: v,
-                        },
-                      })
-                    }
-                  />
-                </FieldRow>
-
                 <FieldRow label="Performance Waterfall">
                   <Toggle
                     label="Show performance waterfall pane"

--- a/src/hooks/useAdoIntegration.ts
+++ b/src/hooks/useAdoIntegration.ts
@@ -61,6 +61,16 @@ export function useAdoIntegration(workstreamName: string | null, sessions: Sessi
     return Array.from(uniqueBranches)
   }, [sessions])
 
+  // Extract a common repository from sessions — only use if all sessions share the same repo
+  const commonRepository = useMemo(() => {
+    const repos = new Set(
+      sessions
+        .map((s) => s.repository)
+        .filter((r): r is string => Boolean(r && r.trim())),
+    )
+    return repos.size === 1 ? Array.from(repos)[0] : undefined
+  }, [sessions])
+
   useEffect(() => {
     let isCancelled = false
 
@@ -113,7 +123,7 @@ export function useAdoIntegration(workstreamName: string | null, sessions: Sessi
     setIsLoadingPRs(true)
     setPrError(null)
 
-    getPullRequests(branches)
+    getPullRequests(branches, commonRepository)
       .then((prs) => {
         setPullRequests(prs)
       })
@@ -125,7 +135,7 @@ export function useAdoIntegration(workstreamName: string | null, sessions: Sessi
       .finally(() => {
         setIsLoadingPRs(false)
       })
-  }, [branches, isAdoConfigured, workstreamName])
+  }, [branches, commonRepository, isAdoConfigured, workstreamName])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/hooks/useSessionDeliverables.ts
+++ b/src/hooks/useSessionDeliverables.ts
@@ -2,6 +2,12 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { getSessionDeliverables } from '../services/adoService'
 import type { AdoPullRequest, AdoWorkItem } from '../types/ado'
 
+export interface AdoContext {
+  organization?: string;
+  project?: string;
+  repository?: string;
+}
+
 export interface UseSessionDeliverablesResult {
   pullRequests: AdoPullRequest[]
   workItems: AdoWorkItem[]
@@ -13,6 +19,7 @@ export interface UseSessionDeliverablesResult {
 export function useSessionDeliverables(
   branch: string | null | undefined,
   isAdoConfigured: boolean,
+  adoContext?: AdoContext,
 ): UseSessionDeliverablesResult {
   const [pullRequests, setPullRequests] = useState<AdoPullRequest[]>([])
   const [workItems, setWorkItems] = useState<AdoWorkItem[]>([])
@@ -38,7 +45,12 @@ export function useSessionDeliverables(
     setIsLoading(true)
     setError(null)
 
-    getSessionDeliverables(branch)
+    getSessionDeliverables(
+      branch,
+      adoContext?.repository,
+      adoContext?.organization,
+      adoContext?.project,
+    )
       .then((data) => {
         if (!controller.signal.aborted) {
           setPullRequests(data.pullRequests)
@@ -58,7 +70,7 @@ export function useSessionDeliverables(
           setIsLoading(false)
         }
       })
-  }, [branch, isAdoConfigured])
+  }, [branch, isAdoConfigured, adoContext?.repository, adoContext?.organization, adoContext?.project])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/services/adoService.ts
+++ b/src/services/adoService.ts
@@ -13,14 +13,18 @@ export async function getWorkItems(ids: number[]): Promise<AdoWorkItem[]> {
   return res.json();
 }
 
-export async function getPullRequests(branches: string[]): Promise<AdoPullRequest[]> {
+export async function getPullRequests(branches: string[], repository?: string): Promise<AdoPullRequest[]> {
   if (branches.length === 0) return [];
-  const res = await fetch(`/api/ado/pullrequests?branches=${branches.map(encodeURIComponent).join(',')}`);
+  let url = `/api/ado/pullrequests?branches=${branches.map(encodeURIComponent).join(',')}`;
+  if (repository) {
+    url += `&repository=${encodeURIComponent(repository)}`;
+  }
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch pull requests: ${res.status}`);
   return res.json();
 }
 
-export async function updateAdoConfig(config: { organization?: string; project?: string }): Promise<AdoStatus> {
+export async function updateAdoConfig(config: { organization?: string; project?: string; repository?: string; filterByCreator?: boolean }): Promise<AdoStatus> {
   const res = await fetch('/api/ado/config', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
@@ -33,8 +37,17 @@ export async function updateAdoConfig(config: { organization?: string; project?:
   return res.json();
 }
 
-export async function getSessionDeliverables(branch: string): Promise<SessionDeliverables> {
-  const res = await fetch(`/api/ado/session-deliverables?branch=${encodeURIComponent(branch)}`);
+export async function getSessionDeliverables(
+  branch: string,
+  repository?: string,
+  organization?: string,
+  project?: string,
+): Promise<SessionDeliverables> {
+  const params = new URLSearchParams({ branch });
+  if (repository) params.set('repository', repository);
+  if (organization) params.set('organization', organization);
+  if (project) params.set('project', project);
+  const res = await fetch(`/api/ado/session-deliverables?${params}`);
   if (!res.ok) throw new Error(`Failed to fetch session deliverables: ${res.status}`);
   return res.json();
 }

--- a/src/types/ado.ts
+++ b/src/types/ado.ts
@@ -29,11 +29,8 @@ export interface AdoStatus {
   configured: boolean;
   organization: string;
   project: string;
-}
-
-export interface SessionDeliverables {
-  pullRequests: AdoPullRequest[];
-  workItems: AdoWorkItem[];
+  repository: string;
+  filterByCreator: boolean;
 }
 
 export interface SessionDeliverables {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -13,7 +13,6 @@ export type ShellType = 'pwsh' | 'powershell' | 'cmd' | 'bash' | 'custom';
 
 export interface PaneVisibility {
   gitContext: boolean;
-  quickStats: boolean;
   performanceWaterfall: boolean;
   agentHierarchy: boolean;
   eventTimeline: boolean;
@@ -85,7 +84,6 @@ export const DEFAULT_SETTINGS: AppSettings = {
     customShellPath: '',
     paneVisibility: {
       gitContext: true,
-      quickStats: true,
       performanceWaterfall: false,
       agentHierarchy: true,
       eventTimeline: true,


### PR DESCRIPTION
## What changed

### ADO Pane — Per-Session Context
- PRs now scoped to the correct repository (not all repos in the project)
- Session mapper reads branch/repository/host_type from workspace.yaml
- Per-session org/project/repo passed through to ADO API calls
- PR URLs use the session's project, not the global config
- Opt-in creator filter (default off)
- Config: \doRepository\, \doFilterByCreator\ persisted to disk

### Session Detail — Inline Agent Stats  
- Running/Blocked/Waiting/Completed counts in the header metadata row
- Color-coded with status colors, checkmark when all done
- Removed the Quick Stats card grid (redundant)

### Status Bar — Waiting Popover
- Pulsing amber dot on 'Waiting' when sessions need input
- Hover shows popover listing waiting sessions
- Click any session to navigate directly to it

### 6 commits, ~20 files touched