### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to Rocinante will be documented in this file.
 
+## [1.6.0] - 2026-04-22
+
+### Added
+- **Per-session ADO context** — PR queries now use each session's own ADO organization and project (from workspace.yaml) instead of the global config. Sessions across different ADO projects show the correct PRs and work items
+- **Repository-scoped PR fetching** — PRs filtered by specific repository (both MCP and REST paths), eliminating cross-repo noise from the ADO pane
+- **Workspace metadata reader** — session mapper reads branch, repository, and host_type from workspace.yaml, providing accurate session-time values instead of stale git HEAD / basename fallbacks
+- **Inline agent stats** — Running/Blocked/Waiting/Completed counts displayed in the session header metadata row with color-coded status text
+- **Waiting sessions popover** — status bar "Waiting" indicator pulses amber when sessions need input; hover reveals a popover listing each waiting session; click to navigate directly
+- **Opt-in creator filter** — `adoFilterByCreator` config option (default off) filters PRs by the authenticated ADO user
+- **ADO repository config** — `adoRepository` field in server config, persisted to `~/.rocinante/ado-config.json`, configurable via env var `ADO_REPOSITORY`
+- **Per-session ADO API params** — session-deliverables endpoint accepts `organization`, `project`, and `repository` query params for per-session overrides
+
+### Changed
+- **Quick Stats removed** — the StatCard grid pane replaced by compact inline agent status in the header metadata row
+- **`quickStats` setting removed** — the pane visibility toggle no longer exists in settings
+
+### Fixed
+- **Wrong-project PRs** — sessions from `DefenderCommon` no longer show PRs from `Windows Defender` (or any other globally-configured project)
+- **Stale branch data** — session branch now comes from workspace.yaml (session-time value) instead of current git HEAD which may have changed
+- **PR link URLs** — `buildPrUrl` fallback now uses per-session org/project instead of global config, producing correct ADO links
+- **Hover popover gap** — waiting sessions popover uses transparent bridge padding so mouse can reach clickable session buttons
+
 ## [1.2.1] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Named after the ship from *The Expanse*, which was named after Don Quixote's hor
 - **Light/Dark Mode**: Full theme support with system preference detection
 - **Real-time Updates**: Auto-refresh with configurable interval
 
+### Azure DevOps Integration
+- **Per-session PR/work item display**: Each session shows PRs and work items from its own ADO project — not just the globally configured one
+- **Repository scoping**: PR queries filtered to the specific repository, no cross-repo noise
+- **Workspace-aware metadata**: Branch and repository read from Copilot CLI's workspace.yaml for accurate session context
+- **Configurable**: Set ADO org/project/repository via Settings, `~/.rocinante/ado-config.json`, or environment variables (`ADO_ORG`, `ADO_PROJECT`, `ADO_REPOSITORY`)
+- **MCP + REST dual path**: Uses ADO MCP server when available, falls back to direct REST API calls
+- **Optional creator filter**: Filter PRs to only those created by the authenticated user (`ADO_FILTER_BY_CREATOR=true`)
+
+### Status Bar
+- **Waiting sessions popover**: Pulsing amber indicator when sessions need user input — hover to see which sessions, click to navigate
+- **Inline agent stats**: Running/Blocked/Waiting/Completed counts shown directly in the session header metadata row
+
 ## User Guide
 
 For a comprehensive guide on using the dashboard, see **[docs/user-guide.md](./docs/user-guide.md)**. It covers the kanban board, search, auto-grouping, session details, settings, demo mode, and more.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -17,9 +17,10 @@ See `screenshot.png` in the project root for an example of the kanban board.
 5. [Session Detail Panel](#session-detail-panel)
 6. [Auto-Archive Rules](#auto-archive-rules)
 7. [Settings](#settings)
-8. [Demo Mode](#demo-mode)
-9. [Status Filters](#status-filters)
-10. [Tips](#tips)
+8. [Azure DevOps Integration](#azure-devops-integration)
+9. [Demo Mode](#demo-mode)
+10. [Status Filters](#status-filters)
+11. [Tips](#tips)
 
 ---
 
@@ -261,6 +262,35 @@ Shows the current version number and a link to the GitHub repository.
 ### Reset to Defaults
 
 A button at the bottom of the settings panel resets all settings to their defaults.
+
+---
+
+## Azure DevOps Integration
+
+Rocinante can display Pull Requests and Work Items from Azure DevOps alongside your sessions.
+
+### Configuration
+
+Set your ADO connection in **Settings > Azure DevOps**, or configure via environment variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ADO_ORG` | ADO organization name | `microsoft` |
+| `ADO_PROJECT` | ADO project name | `WDATP` |
+| `ADO_REPOSITORY` | Repository name (optional) | `InE.AlertsApiService` |
+| `ADO_FILTER_BY_CREATOR` | Only show your PRs (opt-in) | `true` |
+
+Configuration persists to `~/.rocinante/ado-config.json`.
+
+### Per-Session Context
+
+Rocinante reads each session's workspace.yaml to determine which ADO project the session belongs to. This means sessions from different ADO projects show the correct PRs automatically — no manual config switching needed.
+
+The `repository` field in workspace.yaml follows the format `{org}/{project}/{repo}` for ADO-hosted sessions, which Rocinante parses to query the right ADO project.
+
+### Waiting Sessions
+
+When sessions are waiting for user input (e.g., `ask_user` tool), the **Waiting** indicator in the status bar pulses amber. Hover to see a list of waiting sessions, and click any session to navigate directly to it.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rocinante",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A real-time dashboard for monitoring and interacting with GitHub Copilot CLI sessions. Named after the ship from The Expanse, which was named after Don Quixote's horse — a workhorse.",
   "author": "gaburn",
   "license": "MIT",


### PR DESCRIPTION
## Release v1.6.0

### What's new
- Per-session ADO context (PRs scoped to correct org/project/repo)
- Workspace metadata reader (branch/repo from workspace.yaml)
- Inline agent stats in session header
- Waiting sessions popover in status bar
- Opt-in creator filter for PRs

### Docs
- CHANGELOG updated with full feature list
- README now covers ADO integration + status bar features
- User guide adds ADO configuration section

### Version
- package.json bumped to 1.6.0
- Tag \1.6.0\ will be created after merge