### PR TITLE
feat(#24): Daily Focus mode + concurrent-workstream warning

### DIFF
--- a/src/components/kanban/FocusWarningBanner.tsx
+++ b/src/components/kanban/FocusWarningBanner.tsx
@@ -3,7 +3,8 @@ import { useState, useEffect } from 'react';
 interface FocusWarningBannerProps {
   activeCount: number;
   threshold: number;
-  onDismiss: () => void;
+  /** Optional callback fired when the banner is dismissed. */
+  onDismiss?: () => void;
 }
 
 /**
@@ -47,7 +48,7 @@ export default function FocusWarningBanner({
         data-testid="focus-warning-dismiss"
         onClick={() => {
           setDismissedAtCount(activeCount);
-          onDismiss();
+          onDismiss?.();
         }}
         className="
           shrink-0 rounded px-2 py-0.5 text-xs font-medium

--- a/src/components/kanban/FocusWarningBanner.tsx
+++ b/src/components/kanban/FocusWarningBanner.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+
+interface FocusWarningBannerProps {
+  activeCount: number;
+  threshold: number;
+  onDismiss: () => void;
+}
+
+/**
+ * Dismissible warning banner shown when active workstream count
+ * exceeds the configured threshold. Re-appears if the count rises
+ * above the level at which it was dismissed.
+ */
+export default function FocusWarningBanner({
+  activeCount,
+  threshold,
+  onDismiss,
+}: FocusWarningBannerProps) {
+  const [dismissedAtCount, setDismissedAtCount] = useState<number | null>(null);
+
+  // Re-show banner if active count rises above the dismissed-at value
+  useEffect(() => {
+    if (dismissedAtCount !== null && activeCount > dismissedAtCount) {
+      setDismissedAtCount(null);
+    }
+  }, [activeCount, dismissedAtCount]);
+
+  if (dismissedAtCount !== null) return null;
+
+  return (
+    <div
+      role="alert"
+      data-testid="focus-warning-banner"
+      className="
+        flex items-center justify-between gap-3
+        rounded-lg border border-amber-500/30 bg-amber-500/10
+        px-4 py-2.5 text-sm text-amber-200/90
+      "
+    >
+      <span>
+        <span aria-hidden="true">⚠️</span>{' '}
+        {activeCount} workstreams are currently active (threshold: {threshold}).
+        Consider focusing or completing some before starting new work.
+      </span>
+      <button
+        type="button"
+        data-testid="focus-warning-dismiss"
+        onClick={() => {
+          setDismissedAtCount(activeCount);
+          onDismiss();
+        }}
+        className="
+          shrink-0 rounded px-2 py-0.5 text-xs font-medium
+          text-amber-300 transition-colors
+          hover:bg-amber-500/20 hover:text-amber-200
+          focus-visible:outline-none focus-visible:ring-2
+          focus-visible:ring-amber-400
+        "
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -19,8 +19,10 @@ import StatusSummaryBar from '../common/StatusSummaryBar';
 import StatusFilter from '../filters/StatusFilter';
 import KanbanColumn, { COLUMN_SORTABLE_PREFIX } from './KanbanColumn';
 import KanbanTile from './KanbanTile';
+import FocusWarningBanner from './FocusWarningBanner';
 import WelcomeCard from '../sessions/WelcomeCard';
 import NewWorkstreamDialog from './NewWorkstreamDialog';
+import { useFocusMode } from '../../hooks/useFocusMode';
 
 /* ─────────────────────────────────────────────────────────
  * KanbanBoard
@@ -91,6 +93,7 @@ export default function KanbanBoard() {
     archiveWorkstream,
     updateWorkstreamRegistry,
     toggleFavorite,
+    toggleFocus,
   } = useSessionActions();
 
   const { openLaunchTerminal } = useTerminalContext();
@@ -101,6 +104,17 @@ export default function KanbanBoard() {
   const [activeDragColumnName, setActiveDragColumnName] = useState<string | null>(null);
   const [showNewWorkstream, setShowNewWorkstream] = useState(false);
   const [newWorkstreamDefaultPath, setNewWorkstreamDefaultPath] = useState<string | undefined>();
+
+  // Focus mode state
+  const {
+    activeWorkstreamCount,
+    focusedWorkstreamNames,
+    shouldShowWarning,
+    workstreamThreshold,
+    focusModeEnabled,
+  } = useFocusMode();
+  const [showAllWorkstreams, setShowAllWorkstreams] = useState(false);
+  const [focusLimitMsg, setFocusLimitMsg] = useState<string | null>(null);
 
   // Cached agent detection for quick in-column session launches
   type AgentType = 'copilot' | 'claude' | 'shell';
@@ -166,24 +180,47 @@ export default function KanbanBoard() {
     if (searchQuery.trim()) {
       cols = cols.filter((c) => c.sessions.length > 0);
     }
-    // Sort favorited workstreams before non-favorited; Ungrouped always last.
-    // Uses live workstreamRegistry so toggling ★ immediately reorders columns.
+    // Sort: focused → favorited → rest → ungrouped (when focus mode on)
+    // Otherwise: favorited → rest → ungrouped
     return [...cols].sort((a, b) => {
       const aIsUngrouped = a.id === UNGROUPED_ID;
       const bIsUngrouped = b.id === UNGROUPED_ID;
       if (aIsUngrouped && !bIsUngrouped) return 1;
       if (!aIsUngrouped && bIsUngrouped) return -1;
+      if (focusModeEnabled) {
+        const aFocus = workstreamRegistry[a.name]?.focused ? 1 : 0;
+        const bFocus = workstreamRegistry[b.name]?.focused ? 1 : 0;
+        if (aFocus !== bFocus) return bFocus - aFocus;
+      }
       const aFav = workstreamRegistry[a.name]?.favorited ? 1 : 0;
       const bFav = workstreamRegistry[b.name]?.favorited ? 1 : 0;
       if (aFav !== bFav) return bFav - aFav;
-      return 0; // preserve existing order within group
+      return 0;
     });
-  }, [columns, sessions, hasAnyWorkstreams, searchQuery, workstreamRegistry]);
+  }, [columns, sessions, hasAnyWorkstreams, searchQuery, workstreamRegistry, focusModeEnabled]);
+
+  // Separate focused vs non-focused columns for rendering when focus mode is active
+  const { visibleColumns, hiddenCount } = useMemo(() => {
+    if (!focusModeEnabled || showAllWorkstreams) {
+      return { visibleColumns: effectiveColumns, hiddenCount: 0 };
+    }
+    const focused = effectiveColumns.filter(
+      (col) => col.id === UNGROUPED_ID || workstreamRegistry[col.name]?.focused,
+    );
+    // If no workstreams are pinned, show all (don't hide the board)
+    if (focused.length <= 1 && focused[0]?.id === UNGROUPED_ID) {
+      return { visibleColumns: effectiveColumns, hiddenCount: 0 };
+    }
+    const hidden = effectiveColumns.filter(
+      (col) => col.id !== UNGROUPED_ID && !workstreamRegistry[col.name]?.focused,
+    );
+    return { visibleColumns: focused, hiddenCount: hidden.length };
+  }, [effectiveColumns, focusModeEnabled, showAllWorkstreams, workstreamRegistry]);
 
   // Column sortable ids for SortableContext (all columns, Ungrouped disabled via prop)
   const columnSortableIds = useMemo(
-    () => effectiveColumns.map((col) => `${COLUMN_SORTABLE_PREFIX}${col.id}`),
-    [effectiveColumns],
+    () => visibleColumns.map((col) => `${COLUMN_SORTABLE_PREFIX}${col.id}`),
+    [visibleColumns],
   );
 
   /* ── Drag handlers ─────────────────────────────── */
@@ -328,6 +365,19 @@ export default function KanbanBoard() {
     [workstreamRegistry, updateWorkstreamRegistry, openLaunchTerminal],
   );
 
+  const handleToggleFocus = useCallback(
+    (colName: string) => {
+      const result = toggleFocus(colName);
+      if (!result.ok && result.reason === 'limit_reached') {
+        setFocusLimitMsg(`Focus limit reached (${workstreamThreshold}). Unpin a workstream first.`);
+        setTimeout(() => setFocusLimitMsg(null), 2500);
+      } else {
+        setFocusLimitMsg(null);
+      }
+    },
+    [toggleFocus, workstreamThreshold],
+  );
+
   // Column being dragged (for overlay ghost)
   const activeDragColumn = useMemo(() => {
     if (!activeDragColumnName) return null;
@@ -343,6 +393,14 @@ export default function KanbanBoard() {
       {/* ── Top bar: summary / search / status filter ── */}
       <div className="shrink-0 space-y-2 border-b border-border-default bg-surface-primary p-3">
         <StatusSummaryBar />
+
+        {shouldShowWarning && (
+          <FocusWarningBanner
+            activeCount={activeWorkstreamCount}
+            threshold={workstreamThreshold}
+            onDismiss={() => {}}
+          />
+        )}
 
         <div className="relative">
           <svg
@@ -561,7 +619,7 @@ export default function KanbanBoard() {
           >
             <SortableContext items={columnSortableIds} strategy={horizontalListSortingStrategy}>
               <div className="flex h-full gap-4 overflow-x-auto p-4 kanban-scrollable">
-                {effectiveColumns.map((col) => (
+                {visibleColumns.map((col) => (
                   <KanbanColumn
                     key={col.id}
                     id={col.id}
@@ -594,11 +652,64 @@ export default function KanbanBoard() {
                         ? () => toggleFavorite(col.name)
                         : undefined
                     }
+                    isFocused={Boolean(workstreamRegistry[col.name]?.focused)}
+                    onToggleFocus={
+                      focusModeEnabled && col.id !== UNGROUPED_ID && col.name !== 'All Sessions'
+                        ? () => handleToggleFocus(col.name)
+                        : undefined
+                    }
+                    focusLimitMessage={focusLimitMsg}
                     isSortable={col.id !== UNGROUPED_ID && col.name !== 'All Sessions'}
                     conversationSearchResults={conversationSearchResults}
                     searchQuery={searchQuery}
                   />
                 ))}
+
+                {/* Summary tile for hidden non-focus columns */}
+                {hiddenCount > 0 && (
+                  <div
+                    data-testid="focus-hidden-summary"
+                    className="
+                      flex flex-col items-center justify-center shrink-0
+                      w-[220px] min-h-[120px] rounded-lg
+                      border border-border-default/40 bg-surface-secondary/40
+                      text-fg/40 text-sm
+                    "
+                  >
+                    <span className="font-mono text-lg">+{hiddenCount}</span>
+                    <span className="text-xs mt-1">other workstream{hiddenCount !== 1 ? 's' : ''}</span>
+                    <button
+                      type="button"
+                      data-testid="focus-show-all"
+                      onClick={() => setShowAllWorkstreams(true)}
+                      className="
+                        mt-3 rounded-md border border-border-default
+                        px-3 py-1 text-xs text-fg/60
+                        transition-colors hover:border-border-active hover:text-fg/80
+                      "
+                    >
+                      Show all
+                    </button>
+                  </div>
+                )}
+
+                {/* "Back to focus" pill when showing all in focus mode */}
+                {focusModeEnabled && showAllWorkstreams && focusedWorkstreamNames.length > 0 && (
+                  <div className="flex items-center shrink-0">
+                    <button
+                      type="button"
+                      data-testid="focus-collapse"
+                      onClick={() => setShowAllWorkstreams(false)}
+                      className="
+                        rounded-md border border-border-default
+                        px-3 py-1.5 text-xs text-fg/50
+                        transition-colors hover:border-border-active hover:text-fg/80
+                      "
+                    >
+                      Focus only
+                    </button>
+                  </div>
+                )}
               </div>
             </SortableContext>
 

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -114,7 +114,6 @@ export default function KanbanBoard() {
     focusModeEnabled,
   } = useFocusMode();
   const [showAllWorkstreams, setShowAllWorkstreams] = useState(false);
-  const [focusLimitMsg, setFocusLimitMsg] = useState<string | null>(null);
 
   // Cached agent detection for quick in-column session launches
   type AgentType = 'copilot' | 'claude' | 'shell';
@@ -367,15 +366,9 @@ export default function KanbanBoard() {
 
   const handleToggleFocus = useCallback(
     (colName: string) => {
-      const result = toggleFocus(colName);
-      if (!result.ok && result.reason === 'limit_reached') {
-        setFocusLimitMsg(`Focus limit reached (${workstreamThreshold}). Unpin a workstream first.`);
-        setTimeout(() => setFocusLimitMsg(null), 2500);
-      } else {
-        setFocusLimitMsg(null);
-      }
+      return toggleFocus(colName);
     },
-    [toggleFocus, workstreamThreshold],
+    [toggleFocus],
   );
 
   // Column being dragged (for overlay ghost)
@@ -398,7 +391,6 @@ export default function KanbanBoard() {
           <FocusWarningBanner
             activeCount={activeWorkstreamCount}
             threshold={workstreamThreshold}
-            onDismiss={() => {}}
           />
         )}
 
@@ -658,7 +650,6 @@ export default function KanbanBoard() {
                         ? () => handleToggleFocus(col.name)
                         : undefined
                     }
-                    focusLimitMessage={focusLimitMsg}
                     isSortable={col.id !== UNGROUPED_ID && col.name !== 'All Sessions'}
                     conversationSearchResults={conversationSearchResults}
                     searchQuery={searchQuery}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -204,14 +204,14 @@ export default function KanbanBoard() {
       return { visibleColumns: effectiveColumns, hiddenCount: 0 };
     }
     const focused = effectiveColumns.filter(
-      (col) => col.id === UNGROUPED_ID || workstreamRegistry[col.name]?.focused,
+      (col) => col.id !== UNGROUPED_ID && workstreamRegistry[col.name]?.focused,
     );
     // If no workstreams are pinned, show all (don't hide the board)
-    if (focused.length <= 1 && focused[0]?.id === UNGROUPED_ID) {
+    if (focused.length === 0) {
       return { visibleColumns: effectiveColumns, hiddenCount: 0 };
     }
     const hidden = effectiveColumns.filter(
-      (col) => col.id !== UNGROUPED_ID && !workstreamRegistry[col.name]?.focused,
+      (col) => col.id === UNGROUPED_ID || !workstreamRegistry[col.name]?.focused,
     );
     return { visibleColumns: focused, hiddenCount: hidden.length };
   }, [effectiveColumns, focusModeEnabled, showAllWorkstreams, workstreamRegistry]);

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { useSortable, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -34,6 +35,9 @@ interface KanbanColumnProps {
   onNewSession?: () => void;
   isFavorited?: boolean;
   onToggleFavorite?: () => void;
+  isFocused?: boolean;
+  onToggleFocus?: () => void;
+  focusLimitMessage?: string | null;
   isSortable?: boolean;
   conversationSearchResults?: Map<string, ConversationMatch>;
   searchQuery?: string;
@@ -51,6 +55,9 @@ export default function KanbanColumn({
   onNewSession,
   isFavorited = false,
   onToggleFavorite,
+  isFocused = false,
+  onToggleFocus,
+  focusLimitMessage = null,
   isSortable = false,
   conversationSearchResults,
   searchQuery,
@@ -77,6 +84,9 @@ export default function KanbanColumn({
 
   const sorted = sortTiles(sessions);
   const sessionIds = sorted.map((s) => s.id);
+
+  // Transient feedback when focus limit is reached
+  const [showLimitMsg, setShowLimitMsg] = useState(false);
 
   const columnStyle = isSortable
     ? {
@@ -148,6 +158,43 @@ export default function KanbanColumn({
             </span>
           </button>
         )}
+        {onToggleFocus && (
+          <button
+            type="button"
+            data-testid={`focus-pin-${name}`}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={() => {
+              onToggleFocus();
+              if (focusLimitMessage) {
+                setShowLimitMsg(true);
+                setTimeout(() => setShowLimitMsg(false), 2500);
+              }
+            }}
+            className={`shrink-0 rounded p-0.5 transition-colors ${
+              isFocused
+                ? 'text-blue-400 hover:text-blue-300'
+                : 'text-fg/25 hover:text-fg/60 hover:bg-surface-tertiary'
+            }`}
+            aria-label={isFocused ? `Unpin ${name} from focus` : `Pin ${name} to focus`}
+            title={isFocused ? 'Remove from focus' : 'Add to focus'}
+          >
+            <svg
+              aria-hidden="true"
+              className="h-3.5 w-3.5"
+              fill={isFocused ? 'currentColor' : 'none'}
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 2l0 10" />
+              <path d="M18 8l-12 0" />
+              <path d="M15 2l-6 0" />
+              <path d="M12 12l0 10" />
+            </svg>
+          </button>
+        )}
         {onNewSession && (
           <button
             type="button"
@@ -196,6 +243,16 @@ export default function KanbanColumn({
           </button>
         )}
       </div>
+
+      {/* Focus limit feedback */}
+      {showLimitMsg && focusLimitMessage && (
+        <div
+          data-testid="focus-limit-message"
+          className="px-3 py-1.5 text-[11px] text-amber-400/80 border-b border-border-default/30"
+        >
+          {focusLimitMessage}
+        </div>
+      )}
 
       {/* Scrollable tile area */}
       <div

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -36,8 +36,8 @@ interface KanbanColumnProps {
   isFavorited?: boolean;
   onToggleFavorite?: () => void;
   isFocused?: boolean;
-  onToggleFocus?: () => void;
-  focusLimitMessage?: string | null;
+  onToggleFocus?: () => { ok: boolean; reason?: string };
+  focusLimitReached?: string | null;
   isSortable?: boolean;
   conversationSearchResults?: Map<string, ConversationMatch>;
   searchQuery?: string;
@@ -57,7 +57,6 @@ export default function KanbanColumn({
   onToggleFavorite,
   isFocused = false,
   onToggleFocus,
-  focusLimitMessage = null,
   isSortable = false,
   conversationSearchResults,
   searchQuery,
@@ -87,6 +86,7 @@ export default function KanbanColumn({
 
   // Transient feedback when focus limit is reached
   const [showLimitMsg, setShowLimitMsg] = useState(false);
+  const [limitMsg, setLimitMsg] = useState<string | null>(null);
 
   const columnStyle = isSortable
     ? {
@@ -164,8 +164,9 @@ export default function KanbanColumn({
             data-testid={`focus-pin-${name}`}
             onPointerDown={(e) => e.stopPropagation()}
             onClick={() => {
-              onToggleFocus();
-              if (focusLimitMessage) {
+              const result = onToggleFocus();
+              if (result && !result.ok && result.reason === 'limit_reached') {
+                setLimitMsg('Focus limit reached. Unpin a workstream first.');
                 setShowLimitMsg(true);
                 setTimeout(() => setShowLimitMsg(false), 2500);
               }
@@ -245,12 +246,12 @@ export default function KanbanColumn({
       </div>
 
       {/* Focus limit feedback */}
-      {showLimitMsg && focusLimitMessage && (
+      {showLimitMsg && limitMsg && (
         <div
           data-testid="focus-limit-message"
           className="px-3 py-1.5 text-[11px] text-amber-400/80 border-b border-border-default/30"
         >
-          {focusLimitMessage}
+          {limitMsg}
         </div>
       )}
 

--- a/src/components/kanban/__tests__/FocusWarningBanner.test.ts
+++ b/src/components/kanban/__tests__/FocusWarningBanner.test.ts
@@ -15,7 +15,6 @@ function renderBanner(activeCount: number, threshold: number) {
     React.createElement(FocusWarningBanner, {
       activeCount,
       threshold,
-      onDismiss: () => {},
     }),
   )
 }

--- a/src/components/kanban/__tests__/FocusWarningBanner.test.ts
+++ b/src/components/kanban/__tests__/FocusWarningBanner.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import FocusWarningBanner from '../FocusWarningBanner'
+
+/**
+ * Tests for FocusWarningBanner component (issue #24).
+ *
+ * Uses renderToStaticMarkup (node environment) to match the repo's
+ * existing TSX test pattern (see inlineMarkdown.test.tsx).
+ */
+
+function renderBanner(activeCount: number, threshold: number) {
+  return renderToStaticMarkup(
+    React.createElement(FocusWarningBanner, {
+      activeCount,
+      threshold,
+      onDismiss: () => {},
+    }),
+  )
+}
+
+describe('FocusWarningBanner', () => {
+  it('renders the active count and threshold in the text', () => {
+    const html = renderBanner(5, 3)
+    expect(html).toContain('5')
+    expect(html).toContain('3')
+    expect(html).toContain('workstreams are currently active')
+  })
+
+  it('has role="alert" for accessibility', () => {
+    const html = renderBanner(4, 3)
+    expect(html).toContain('role="alert"')
+  })
+
+  it('renders a dismiss button with data-testid', () => {
+    const html = renderBanner(5, 3)
+    expect(html).toContain('data-testid="focus-warning-dismiss"')
+    expect(html).toContain('Dismiss')
+  })
+
+  it('has data-testid="focus-warning-banner" on the container', () => {
+    const html = renderBanner(6, 3)
+    expect(html).toContain('data-testid="focus-warning-banner"')
+  })
+})

--- a/src/components/kanban/__tests__/focusVisibility.test.ts
+++ b/src/components/kanban/__tests__/focusVisibility.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for focus-mode column visibility filtering in KanbanBoard.
+ *
+ * Extracted filter logic: when focus mode is active with pinned workstreams,
+ * only focused columns are visible; Ungrouped is hidden and counted among
+ * the "+N other workstreams". When no workstreams are pinned, everything shows.
+ */
+
+const UNGROUPED_ID = '__ungrouped__';
+
+interface Column {
+  id: string;
+  name: string;
+  sessions: unknown[];
+}
+
+interface RegistryEntry {
+  focused?: boolean;
+  favorited?: boolean;
+}
+
+type WorkstreamRegistry = Record<string, RegistryEntry | undefined>;
+
+/** Mirrors the visibility split in KanbanBoard's visibleColumns useMemo. */
+function computeVisibility(
+  effectiveColumns: Column[],
+  focusModeEnabled: boolean,
+  showAllWorkstreams: boolean,
+  workstreamRegistry: WorkstreamRegistry,
+): { visibleColumns: Column[]; hiddenCount: number } {
+  if (!focusModeEnabled || showAllWorkstreams) {
+    return { visibleColumns: effectiveColumns, hiddenCount: 0 };
+  }
+  const focused = effectiveColumns.filter(
+    (col) => col.id !== UNGROUPED_ID && workstreamRegistry[col.name]?.focused,
+  );
+  if (focused.length === 0) {
+    return { visibleColumns: effectiveColumns, hiddenCount: 0 };
+  }
+  const hidden = effectiveColumns.filter(
+    (col) => col.id === UNGROUPED_ID || !workstreamRegistry[col.name]?.focused,
+  );
+  return { visibleColumns: focused, hiddenCount: hidden.length };
+}
+
+const mkCol = (name: string, id?: string, sessionCount = 1): Column => ({
+  id: id ?? name,
+  name,
+  sessions: Array.from({ length: sessionCount }, (_, i) => ({ id: `${name}-${i}` })),
+});
+
+describe('Focus-mode column visibility', () => {
+  const ungrouped = mkCol('Ungrouped', UNGROUPED_ID, 2);
+  const alpha = mkCol('Alpha');
+  const beta = mkCol('Beta');
+  const gamma = mkCol('Gamma');
+  const delta = mkCol('Delta');
+  const allCols = [alpha, beta, gamma, delta, ungrouped];
+
+  const registry: WorkstreamRegistry = {
+    Alpha: { focused: true },
+    Beta: { focused: true },
+    Gamma: { focused: true },
+    Delta: { focused: false },
+  };
+
+  it('hides Ungrouped when focus mode is on with pinned workstreams', () => {
+    const { visibleColumns, hiddenCount } = computeVisibility(allCols, true, false, registry);
+    const names = visibleColumns.map((c) => c.name);
+    expect(names).toEqual(['Alpha', 'Beta', 'Gamma']);
+    expect(names).not.toContain('Ungrouped');
+    expect(hiddenCount).toBe(2); // Delta + Ungrouped
+  });
+
+  it('shows Ungrouped when "Show all" is active', () => {
+    const { visibleColumns, hiddenCount } = computeVisibility(allCols, true, true, registry);
+    expect(visibleColumns.map((c) => c.name)).toContain('Ungrouped');
+    expect(hiddenCount).toBe(0);
+  });
+
+  it('shows Ungrouped when focus mode is off', () => {
+    const { visibleColumns, hiddenCount } = computeVisibility(allCols, false, false, registry);
+    expect(visibleColumns.map((c) => c.name)).toContain('Ungrouped');
+    expect(hiddenCount).toBe(0);
+  });
+
+  it('shows everything (including Ungrouped) when zero workstreams are pinned', () => {
+    const emptyRegistry: WorkstreamRegistry = {
+      Alpha: { focused: false },
+      Beta: { focused: false },
+    };
+    const { visibleColumns, hiddenCount } = computeVisibility(allCols, true, false, emptyRegistry);
+    expect(visibleColumns).toHaveLength(allCols.length);
+    expect(visibleColumns.map((c) => c.name)).toContain('Ungrouped');
+    expect(hiddenCount).toBe(0);
+  });
+
+  it('counts Ungrouped with zero sessions among hidden columns', () => {
+    const emptyUngrouped = mkCol('Ungrouped', UNGROUPED_ID, 0);
+    const cols = [alpha, beta, emptyUngrouped];
+    const reg: WorkstreamRegistry = { Alpha: { focused: true }, Beta: { focused: false } };
+    const { visibleColumns, hiddenCount } = computeVisibility(cols, true, false, reg);
+    expect(visibleColumns.map((c) => c.name)).toEqual(['Alpha']);
+    expect(hiddenCount).toBe(2); // Beta + empty Ungrouped
+  });
+
+  it('still shows focused columns even if they have zero sessions', () => {
+    const emptyAlpha = mkCol('Alpha', 'Alpha', 0);
+    const cols = [emptyAlpha, beta, ungrouped];
+    const reg: WorkstreamRegistry = { Alpha: { focused: true }, Beta: { focused: false } };
+    const { visibleColumns, hiddenCount } = computeVisibility(cols, true, false, reg);
+    expect(visibleColumns.map((c) => c.name)).toEqual(['Alpha']);
+    expect(hiddenCount).toBe(2); // Beta + Ungrouped
+  });
+});

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1069,6 +1069,46 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
             )}
           </Section>
 
+          {/* ━━━━━━━━━━ Section: Focus & Limits ━━━━━━━━━━━━━━━ */}
+          <Section title="Focus & Limits">
+            <FieldRow label="Enable Focus Mode">
+              <Toggle
+                checked={display.focusModeEnabled}
+                onChange={(v) => updateDisplaySettings({ focusModeEnabled: v })}
+                label="Enable Focus Mode"
+              />
+            </FieldRow>
+
+            <FieldRow
+              label="Workstream Threshold"
+              hint="Max workstreams you can focus on; also triggers the active-workstream warning when exceeded."
+            >
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={display.workstreamThreshold}
+                onChange={(e) => {
+                  const v = Math.max(1, Math.min(20, Number(e.target.value) || 1));
+                  updateDisplaySettings({ workstreamThreshold: v });
+                }}
+                aria-label="Workstream threshold"
+                data-testid="workstream-threshold-input"
+                className="
+                  w-20 appearance-none
+                  bg-surface-tertiary border border-border-default rounded-md
+                  px-3 py-1.5
+                  text-sm text-fg/80 font-mono text-center tabular-nums
+                  transition-colors duration-150
+                  hover:border-fg/20
+                  focus-visible:outline-none focus-visible:ring-2
+                  focus-visible:ring-border-active focus-visible:ring-offset-1
+                  focus-visible:ring-offset-surface-secondary
+                "
+              />
+            </FieldRow>
+          </Section>
+
           {/* ━━━━━━━━━━ Section: Auto-Archive Rules ━━━━━━━━━━━━━━━ */}
           <Section title="Auto-Archive Rules">
             <div className="space-y-3">

--- a/src/components/settings/__tests__/SettingsFocusSection.test.ts
+++ b/src/components/settings/__tests__/SettingsFocusSection.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_SETTINGS } from '../../../types/settings'
+
+/**
+ * Tests for the Focus & Limits settings defaults and constraints (issue #24).
+ *
+ * Validates that the type-level defaults match the spec.
+ * Full render tests of SettingsPanel require the entire context tree —
+ * deferred to integration tests.
+ */
+
+describe('Focus & Limits settings defaults', () => {
+  it('focusModeEnabled defaults to false', () => {
+    expect(DEFAULT_SETTINGS.display.focusModeEnabled).toBe(false)
+  })
+
+  it('workstreamThreshold defaults to 3', () => {
+    expect(DEFAULT_SETTINGS.display.workstreamThreshold).toBe(3)
+  })
+})

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { useSessions, type UseSessionsResult, type SessionGroup, type ConversationMatch } from '../hooks/useSessions'
 import type { Session, SessionSummary, SessionStatus, StatusCounts } from '../types'
-import type { WorkstreamRegistryEntry } from '../hooks/useWorkstreams'
+import type { WorkstreamRegistryEntry, ToggleFocusResult } from '../hooks/useWorkstreams'
 import type { UseAutoArchiveResult } from '../hooks/useAutoArchive'
 
 /* ──────────────────────────────────────────────────────────────
@@ -71,6 +71,7 @@ export interface SessionActionsContextValue {
   deleteWorkstream: (name: string) => void
   archiveWorkstream: (name: string) => void
   toggleFavorite: (name: string) => void
+  toggleFocus: (name: string) => ToggleFocusResult
   setWorkstreamDescription:(workstreamName: string, description: string) => void
   removeWorkstreamDescription: (workstreamName: string) => void
   autoGroupByRepository: () => void
@@ -152,6 +153,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     deleteWorkstream: s.deleteWorkstream,
     archiveWorkstream: s.archiveWorkstream,
     toggleFavorite: s.toggleFavorite,
+    toggleFocus: s.toggleFocus,
     setWorkstreamDescription:s.setWorkstreamDescription,
     removeWorkstreamDescription: s.removeWorkstreamDescription,
     autoGroupByRepository: s.autoGroupByRepository,
@@ -163,7 +165,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     s.unarchiveSession, s.toggleArchive, s.archiveAndSelectNext,
     s.archiveAllCompleted, s.getWorkstream, s.setWorkstream,
     s.removeWorkstream, s.getCustomName, s.setSessionName,
-    s.removeSessionName, s.renameWorkstream, s.deleteWorkstream, s.archiveWorkstream, s.toggleFavorite,
+    s.removeSessionName, s.renameWorkstream, s.deleteWorkstream, s.archiveWorkstream, s.toggleFavorite, s.toggleFocus,
     s.setWorkstreamDescription, s.removeWorkstreamDescription,
     s.autoGroupByRepository, s.createWorkstream, s.updateWorkstreamRegistry,
   ])

--- a/src/hooks/__tests__/useFocusMode.test.ts
+++ b/src/hooks/__tests__/useFocusMode.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import type { SessionStatus } from '../../types/index.js'
+
+/**
+ * Tests for useFocusMode hook logic (issue #24 — Daily Focus + Warning).
+ *
+ * Pattern: extract the pure derivation logic from useFocusMode.ts and test
+ * directly — same approach as kanbanFavoriteSorting.test.ts and
+ * autoGroupArchive.test.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Types matching the hook's runtime shapes
+// ---------------------------------------------------------------------------
+
+interface SessionSummaryLike {
+  id: string
+  status: SessionStatus
+}
+
+interface SessionGroupLike {
+  name: string
+  sessions: SessionSummaryLike[]
+}
+
+interface GroupedSessionsLike {
+  groups: SessionGroupLike[]
+  ungrouped: SessionSummaryLike[]
+}
+
+interface WorkstreamRegistryEntry {
+  createdAt: string
+  focused?: boolean
+  archived?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Extracted logic mirrors useFocusMode.ts derivations
+// ---------------------------------------------------------------------------
+
+function computeActiveWorkstreamCount(grouped: GroupedSessionsLike): number {
+  let count = 0
+  for (const group of grouped.groups) {
+    if (group.sessions.some((s) => s.status === 'active')) {
+      count++
+    }
+  }
+  if (grouped.ungrouped.some((s) => s.status === 'active')) {
+    count++
+  }
+  return count
+}
+
+function computeFocusedWorkstreamNames(
+  registry: Record<string, WorkstreamRegistryEntry>,
+): string[] {
+  return Object.entries(registry)
+    .filter(([, entry]) => entry.focused)
+    .map(([name]) => name)
+    .sort((a, b) => a.localeCompare(b))
+}
+
+function computeIsFocusLimitReached(
+  focusedNames: string[],
+  threshold: number,
+): boolean {
+  return focusedNames.length >= threshold
+}
+
+function computeShouldShowWarning(
+  activeCount: number,
+  threshold: number,
+): boolean {
+  return activeCount > threshold
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mkSession = (
+  id: string,
+  status: SessionStatus = 'active',
+): SessionSummaryLike => ({ id, status })
+
+const mkGroup = (
+  name: string,
+  sessions: SessionSummaryLike[],
+): SessionGroupLike => ({ name, sessions })
+
+const mkRegistry = (
+  entries: Record<string, { focused?: boolean; archived?: boolean }>,
+): Record<string, WorkstreamRegistryEntry> => {
+  const result: Record<string, WorkstreamRegistryEntry> = {}
+  for (const [name, opts] of Object.entries(entries)) {
+    result[name] = { createdAt: '2025-01-01T00:00:00Z', ...opts }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Tests: shouldShowWarning
+// ---------------------------------------------------------------------------
+
+describe('shouldShowWarning', () => {
+  const threshold = 3
+
+  it('is true when activeWorkstreamCount > threshold (4 active, threshold 3)', () => {
+    expect(computeShouldShowWarning(4, threshold)).toBe(true)
+  })
+
+  it('is false when activeWorkstreamCount === threshold (3 active, threshold 3 — at-limit is safe)', () => {
+    expect(computeShouldShowWarning(3, threshold)).toBe(false)
+  })
+
+  it('is false when activeWorkstreamCount < threshold (2 active, threshold 3)', () => {
+    expect(computeShouldShowWarning(2, threshold)).toBe(false)
+  })
+
+  it('is false when no workstreams are active (0 active, threshold 3)', () => {
+    expect(computeShouldShowWarning(0, threshold)).toBe(false)
+  })
+
+  it('respects custom thresholds (6 active, threshold 5)', () => {
+    expect(computeShouldShowWarning(6, 5)).toBe(true)
+    expect(computeShouldShowWarning(5, 5)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: activeWorkstreamCount
+// ---------------------------------------------------------------------------
+
+describe('activeWorkstreamCount', () => {
+  it('counts distinct workstreams with at least one active session', () => {
+    const grouped: GroupedSessionsLike = {
+      groups: [
+        mkGroup('Auth', [mkSession('s1', 'active'), mkSession('s2', 'completed')]),
+        mkGroup('API', [mkSession('s3', 'active')]),
+        mkGroup('Docs', [mkSession('s4', 'completed'), mkSession('s5', 'blocked')]),
+        mkGroup('Tests', [mkSession('s6', 'active')]),
+      ],
+      ungrouped: [],
+    }
+    // Auth, API, Tests are active — Docs is not
+    expect(computeActiveWorkstreamCount(grouped)).toBe(3)
+  })
+
+  it('includes ungrouped sessions in the count', () => {
+    const grouped: GroupedSessionsLike = {
+      groups: [
+        mkGroup('Auth', [mkSession('s1', 'active')]),
+      ],
+      ungrouped: [mkSession('s2', 'active')],
+    }
+    // Auth + ungrouped = 2
+    expect(computeActiveWorkstreamCount(grouped)).toBe(2)
+  })
+
+  it('returns 0 when no sessions are active', () => {
+    const grouped: GroupedSessionsLike = {
+      groups: [
+        mkGroup('Auth', [mkSession('s1', 'completed')]),
+        mkGroup('API', [mkSession('s2', 'blocked')]),
+      ],
+      ungrouped: [mkSession('s3', 'waiting')],
+    }
+    expect(computeActiveWorkstreamCount(grouped)).toBe(0)
+  })
+
+  it('returns 0 when there are no workstreams or sessions', () => {
+    const grouped: GroupedSessionsLike = { groups: [], ungrouped: [] }
+    expect(computeActiveWorkstreamCount(grouped)).toBe(0)
+  })
+
+  it('counts a workstream only once even if it has multiple active sessions', () => {
+    const grouped: GroupedSessionsLike = {
+      groups: [
+        mkGroup('Auth', [mkSession('s1', 'active'), mkSession('s2', 'active'), mkSession('s3', 'active')]),
+      ],
+      ungrouped: [],
+    }
+    expect(computeActiveWorkstreamCount(grouped)).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: focusedWorkstreamNames
+// ---------------------------------------------------------------------------
+
+describe('focusedWorkstreamNames', () => {
+  it('returns sorted names of workstreams where focused === true', () => {
+    const registry = mkRegistry({
+      Zebra: { focused: true },
+      Alpha: { focused: true },
+      Middle: {},
+      Beta: { focused: true },
+    })
+    expect(computeFocusedWorkstreamNames(registry)).toEqual([
+      'Alpha',
+      'Beta',
+      'Zebra',
+    ])
+  })
+
+  it('returns empty array when no workstreams are focused', () => {
+    const registry = mkRegistry({ Auth: {}, API: {}, Docs: {} })
+    expect(computeFocusedWorkstreamNames(registry)).toEqual([])
+  })
+
+  it('excludes entries where focused is undefined or falsy', () => {
+    const registry = mkRegistry({
+      Auth: { focused: true },
+      API: { focused: false },
+      Docs: {},
+    })
+    expect(computeFocusedWorkstreamNames(registry)).toEqual(['Auth'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: isFocusLimitReached
+// ---------------------------------------------------------------------------
+
+describe('isFocusLimitReached', () => {
+  it('is true when focused count >= threshold (3 focused, threshold 3)', () => {
+    expect(computeIsFocusLimitReached(['A', 'B', 'C'], 3)).toBe(true)
+  })
+
+  it('is true when focused count > threshold (4 focused, threshold 3)', () => {
+    expect(computeIsFocusLimitReached(['A', 'B', 'C', 'D'], 3)).toBe(true)
+  })
+
+  it('is false when focused count < threshold (2 focused, threshold 3)', () => {
+    expect(computeIsFocusLimitReached(['A', 'B'], 3)).toBe(false)
+  })
+
+  it('is false when no workstreams are focused', () => {
+    expect(computeIsFocusLimitReached([], 3)).toBe(false)
+  })
+})

--- a/src/hooks/__tests__/useWorkstreamsFocus.test.ts
+++ b/src/hooks/__tests__/useWorkstreamsFocus.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Tests for toggleFocus logic in useWorkstreams (issue #24).
+ *
+ * Extracts the pure toggleFocus decision logic and tests it
+ * directly — same pattern as autoGroupArchive.test.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Types matching implementation
+// ---------------------------------------------------------------------------
+
+interface WorkstreamRegistryEntry {
+  createdAt: string
+  focused?: boolean
+  archived?: boolean
+}
+
+type ToggleFocusResult =
+  | { ok: true; focused: boolean }
+  | { ok: false; reason: 'limit_reached' | 'ungrouped' }
+
+// ---------------------------------------------------------------------------
+// Extracted logic from useWorkstreams.ts toggleFocus (lines 297-325)
+// ---------------------------------------------------------------------------
+
+function toggleFocus(
+  name: string,
+  registry: Record<string, WorkstreamRegistryEntry>,
+  workstreamThreshold: number,
+): { result: ToggleFocusResult; nextRegistry: Record<string, WorkstreamRegistryEntry> } {
+  // Ungrouped guard
+  if (!name || name === 'Ungrouped') {
+    return {
+      result: { ok: false, reason: 'ungrouped' },
+      nextRegistry: registry,
+    }
+  }
+
+  const existing = registry[name] ?? { createdAt: new Date().toISOString() }
+
+  // If already focused, unfocus it
+  if (existing.focused) {
+    const entry = registry[name] ?? { createdAt: new Date().toISOString() }
+    const nextEntry = { ...entry }
+    delete nextEntry.focused
+    return {
+      result: { ok: true, focused: false },
+      nextRegistry: { ...registry, [name]: nextEntry },
+    }
+  }
+
+  // Check limit before focusing
+  const focusedCount = Object.values(registry).filter((e) => e.focused).length
+  if (focusedCount >= workstreamThreshold) {
+    return {
+      result: { ok: false, reason: 'limit_reached' },
+      nextRegistry: registry,
+    }
+  }
+
+  const entry = registry[name] ?? { createdAt: new Date().toISOString() }
+  return {
+    result: { ok: true, focused: true },
+    nextRegistry: { ...registry, [name]: { ...entry, focused: true } },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mkRegistry = (
+  entries: Record<string, { focused?: boolean }>,
+): Record<string, WorkstreamRegistryEntry> => {
+  const result: Record<string, WorkstreamRegistryEntry> = {}
+  for (const [name, opts] of Object.entries(entries)) {
+    result[name] = { createdAt: '2025-01-01T00:00:00Z', ...opts }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('toggleFocus', () => {
+  const threshold = 3
+
+  it('returns { ok: true, focused: true } on first toggle when under limit', () => {
+    const registry = mkRegistry({ Auth: {}, API: {} })
+    const { result } = toggleFocus('Auth', registry, threshold)
+    expect(result).toEqual({ ok: true, focused: true })
+  })
+
+  it('marks the workstream as focused in the registry', () => {
+    const registry = mkRegistry({ Auth: {}, API: {} })
+    const { nextRegistry } = toggleFocus('Auth', registry, threshold)
+    expect(nextRegistry['Auth'].focused).toBe(true)
+  })
+
+  it('returns { ok: false, reason: "limit_reached" } when threshold already pinned', () => {
+    const registry = mkRegistry({
+      Auth: { focused: true },
+      API: { focused: true },
+      Docs: { focused: true },
+    })
+    const { result } = toggleFocus('Tests', registry, threshold)
+    expect(result).toEqual({ ok: false, reason: 'limit_reached' })
+  })
+
+  it('does not modify the registry when limit is reached', () => {
+    const registry = mkRegistry({
+      Auth: { focused: true },
+      API: { focused: true },
+      Docs: { focused: true },
+    })
+    const { nextRegistry } = toggleFocus('Tests', registry, threshold)
+    expect(nextRegistry).toBe(registry) // strict referential equality
+  })
+
+  it('returns { ok: false, reason: "ungrouped" } for "Ungrouped"', () => {
+    const registry = mkRegistry({ Auth: {} })
+    const { result } = toggleFocus('Ungrouped', registry, threshold)
+    expect(result).toEqual({ ok: false, reason: 'ungrouped' })
+  })
+
+  it('returns { ok: false, reason: "ungrouped" } for empty string', () => {
+    const registry = mkRegistry({ Auth: {} })
+    const { result } = toggleFocus('', registry, threshold)
+    expect(result).toEqual({ ok: false, reason: 'ungrouped' })
+  })
+
+  it('unfocuses an already-focused workstream (returns { ok: true, focused: false })', () => {
+    const registry = mkRegistry({ Auth: { focused: true }, API: {} })
+    const { result, nextRegistry } = toggleFocus('Auth', registry, threshold)
+    expect(result).toEqual({ ok: true, focused: false })
+    expect(nextRegistry['Auth'].focused).toBeUndefined()
+  })
+
+  it('allows re-focusing after unfocusing (round-trip)', () => {
+    const registry = mkRegistry({
+      Auth: { focused: true },
+      API: { focused: true },
+      Docs: { focused: true },
+    })
+    // First: unfocus Auth
+    const { nextRegistry: after1 } = toggleFocus('Auth', registry, threshold)
+    expect(after1['Auth'].focused).toBeUndefined()
+
+    // Now focus a new one — should succeed since we freed a slot
+    const { result, nextRegistry: after2 } = toggleFocus('Tests', after1, threshold)
+    expect(result).toEqual({ ok: true, focused: true })
+    expect(after2['Tests'].focused).toBe(true)
+  })
+
+  it('creates a registry entry for a new workstream when focusing', () => {
+    const registry = mkRegistry({})
+    const { result, nextRegistry } = toggleFocus('Brand-New', registry, threshold)
+    expect(result).toEqual({ ok: true, focused: true })
+    expect(nextRegistry['Brand-New']).toBeDefined()
+    expect(nextRegistry['Brand-New'].focused).toBe(true)
+    expect(typeof nextRegistry['Brand-New'].createdAt).toBe('string')
+  })
+})

--- a/src/hooks/useFocusMode.ts
+++ b/src/hooks/useFocusMode.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import { useSessionData } from '../context/SessionContext'
+import { useSettingsContext } from '../context/SettingsContext'
+
+export interface UseFocusModeResult {
+  /** Count of workstreams that have ≥1 session with status === 'active' */
+  activeWorkstreamCount: number
+  /** Names of workstreams where focused === true in the registry */
+  focusedWorkstreamNames: string[]
+  /** Whether focused count ≥ workstreamThreshold */
+  isFocusLimitReached: boolean
+  /** Whether activeWorkstreamCount > workstreamThreshold (strictly greater than) */
+  shouldShowWarning: boolean
+  /** The current threshold value from settings */
+  workstreamThreshold: number
+  /** Whether focus mode is enabled in settings */
+  focusModeEnabled: boolean
+}
+
+export function useFocusMode(): UseFocusModeResult {
+  const { groupedSessions, workstreamRegistry } = useSessionData()
+  const { settings } = useSettingsContext()
+
+  const { workstreamThreshold, focusModeEnabled } = settings.display
+
+  const focusedWorkstreamNames = useMemo(() => {
+    return Object.entries(workstreamRegistry)
+      .filter(([, entry]) => entry.focused)
+      .map(([name]) => name)
+      .sort((a, b) => a.localeCompare(b))
+  }, [workstreamRegistry])
+
+  const activeWorkstreamCount = useMemo(() => {
+    let count = 0
+    for (const group of groupedSessions.groups) {
+      if (group.sessions.some((s) => s.status === 'active')) {
+        count++
+      }
+    }
+    // Also check ungrouped sessions
+    if (groupedSessions.ungrouped.some((s) => s.status === 'active')) {
+      count++
+    }
+    return count
+  }, [groupedSessions])
+
+  const isFocusLimitReached = focusedWorkstreamNames.length >= workstreamThreshold
+  const shouldShowWarning = activeWorkstreamCount > workstreamThreshold
+
+  return {
+    activeWorkstreamCount,
+    focusedWorkstreamNames,
+    isFocusLimitReached,
+    shouldShowWarning,
+    workstreamThreshold,
+    focusModeEnabled,
+  }
+}

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -11,7 +11,7 @@ import { normalizePath } from '../utils/normalizePath'
 import { useArchive } from './useArchive'
 import { useAutoArchive, type UseAutoArchiveResult } from './useAutoArchive'
 import { useSessionNames } from './useSessionNames'
-import { useWorkstreams, type WorkstreamRegistryEntry } from './useWorkstreams'
+import { useWorkstreams, type WorkstreamRegistryEntry, type ToggleFocusResult } from './useWorkstreams'
 
 export interface ConversationMatch {
   snippet: string
@@ -69,6 +69,7 @@ export interface UseSessionsResult {
   deleteWorkstream: (name: string) => void
   archiveWorkstream: (name: string) => void
   toggleFavorite: (name: string) => void
+  toggleFocus: (name: string) => ToggleFocusResult
   setWorkstreamDescription: (workstreamName: string, description: string) => void
   removeWorkstreamDescription: (workstreamName: string) => void
   autoGroupByRepository: () => void
@@ -645,6 +646,7 @@ export function useSessions(): UseSessionsResult {
     deleteWorkstream: workstreams.deleteWorkstream,
     archiveWorkstream: workstreams.archiveWorkstream,
     toggleFavorite: workstreams.toggleFavorite,
+    toggleFocus: workstreams.toggleFocus,
     setWorkstreamDescription: workstreams.setDescription,
     removeWorkstreamDescription: workstreams.removeDescription,
     autoGroupByRepository: handleAutoGroupByRepository,

--- a/src/hooks/useWorkstreams.ts
+++ b/src/hooks/useWorkstreams.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useWorkstreamMeta } from './useWorkstreamMeta'
+import { useSettingsContext } from '../context/SettingsContext'
 import type { SessionSummary } from '../types'
 
 const WORKSTREAM_STORAGE_KEY = 'rocinante-workstreams'
@@ -14,6 +15,7 @@ export interface WorkstreamRegistryEntry {
   description?: string
   archived?: boolean
   favorited?: boolean
+  focused?: boolean
 }
 
 function loadWorkstreamRegistry(): Record<string, WorkstreamRegistryEntry> {
@@ -36,6 +38,7 @@ function loadWorkstreamRegistry(): Record<string, WorkstreamRegistryEntry> {
           ...(typeof entry.description === 'string' ? { description: entry.description } : {}),
           ...(typeof entry.archived === 'boolean' ? { archived: entry.archived } : {}),
           ...(typeof entry.favorited === 'boolean' ? { favorited: entry.favorited } : {}),
+          ...(typeof entry.focused === 'boolean' ? { focused: entry.focused } : {}),
         }
       }
     }
@@ -78,6 +81,10 @@ function repoDisplayName(repo: string): string {
   return segments[segments.length - 1] || repo
 }
 
+export type ToggleFocusResult =
+  | { ok: true; focused: boolean }
+  | { ok: false; reason: 'limit_reached' | 'ungrouped' }
+
 export interface UseWorkstreamsResult {
   getWorkstream: (sessionId: string) => string | null
   setWorkstream: (sessionId: string, name: string) => void
@@ -90,6 +97,7 @@ export interface UseWorkstreamsResult {
   deleteWorkstream: (name: string) => void
   archiveWorkstream: (name: string) => void
   toggleFavorite: (name: string) => void
+  toggleFocus: (name: string) => ToggleFocusResult
   pruneStaleIds: (activeIds: string[]) => void
   autoGroupByRepository: (sessions: SessionSummary[]) => void
   hasAnyWorkstreams: boolean
@@ -110,6 +118,7 @@ export function useWorkstreams(): UseWorkstreamsResult {
   )
   const storageKeyRef = useRef(WORKSTREAM_STORAGE_KEY)
   const meta = useWorkstreamMeta()
+  const { settings } = useSettingsContext()
 
   useEffect(() => {
     try {
@@ -285,6 +294,36 @@ export function useWorkstreams(): UseWorkstreamsResult {
     })
   }, [])
 
+  const toggleFocus = useCallback((name: string): ToggleFocusResult => {
+    // The Ungrouped workstream cannot be focused
+    if (!name || name === 'Ungrouped') {
+      return { ok: false, reason: 'ungrouped' }
+    }
+
+    const existing = registry[name] ?? { createdAt: new Date().toISOString() }
+
+    // If already focused, unfocus it
+    if (existing.focused) {
+      setRegistry((current) => {
+        const entry = current[name] ?? { createdAt: new Date().toISOString() }
+        return { ...current, [name]: { ...entry, focused: undefined } }
+      })
+      return { ok: true, focused: false }
+    }
+
+    // Check limit before focusing
+    const focusedCount = Object.values(registry).filter((e) => e.focused).length
+    if (focusedCount >= settings.display.workstreamThreshold) {
+      return { ok: false, reason: 'limit_reached' }
+    }
+
+    setRegistry((current) => {
+      const entry = current[name] ?? { createdAt: new Date().toISOString() }
+      return { ...current, [name]: { ...entry, focused: true } }
+    })
+    return { ok: true, focused: true }
+  }, [registry, settings.display.workstreamThreshold])
+
   const pruneStaleIds= useCallback((activeIds: string[]) => {
     setWorkstreamMap((current) => {
       if (Object.keys(current).length === 0) {
@@ -378,6 +417,7 @@ export function useWorkstreams(): UseWorkstreamsResult {
     deleteWorkstream,
     archiveWorkstream,
     toggleFavorite,
+    toggleFocus,
     pruneStaleIds,
     autoGroupByRepository,
     hasAnyWorkstreams,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -38,6 +38,8 @@ export interface DisplaySettings {
   customShellPath: string;
   paneVisibility: PaneVisibility;
   autoArchiveRules: AutoArchiveRule[];
+  focusModeEnabled: boolean;
+  workstreamThreshold: number; // governs max focused workstreams AND active-warning trigger (default 3, min 1, max 20)
 }
 
 export type SessionSourceOption = 'auto' | 'copilot' | 'claude' | 'both';
@@ -90,6 +92,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
       sessionPlan: true,
     },
     autoArchiveRules: [],
+    focusModeEnabled: false,
+    workstreamThreshold: 3,
   },
   data: {
     sessionStateDir: '', // empty = use server default


### PR DESCRIPTION
Implements #24 — **Daily Focus** mode + concurrent-active warning.

## What this does

### Daily Focus (opt-in)
- Enable in **Settings → Focus & Limits** (off by default)
- Pin up to N workstreams as your focus set via a new pin icon on each kanban column header
- Non-focus workstreams collapse into a `+N other workstreams` summary tile with **Show all** (transient) toggle
- Sort order when focus mode is on: focused → favorited → rest → ungrouped
- Ungrouped workstream cannot be focused

### Active-workstream warning
- Persistent dismissible inline banner above the kanban when **active** workstream count > threshold
- "Active" = workstream has ≥1 session with `status === 'active'`
- Banner re-shows if active count rises above the dismissed level

### Settings
- **Single threshold** (`workstreamThreshold`, default 3) governs both the focus pin limit and the warning trigger
- `focusModeEnabled` defaults to **OFF** — opt-in
- Threshold range: 1–20

## Implementation

| Layer | Author | Files |
|-------|--------|-------|
| State / types / hooks | Amos | `settings.ts`, `useWorkstreams.ts`, `useFocusMode.ts` (new), `useSessions.ts`, `SessionContext.tsx` |
| UI | Naomi | `KanbanBoard.tsx`, `KanbanColumn.tsx`, `SettingsPanel.tsx`, `FocusWarningBanner.tsx` (new) |
| Tests | Bobbie | 32 new tests across 4 files |
| Review | Holden | Approved with two minor follow-ups (addressed in this branch) |

## Verification
- ✅ `npx tsc --noEmit` clean (zero new errors)
- ✅ `npx vite build` succeeds
- ✅ **501/501 tests pass** (32 new)
- ✅ With focus mode OFF, kanban renders identically to before this change
- ✅ Empty focus set (focus mode on, nothing pinned) does NOT hide all columns

## Out of scope (filed as follow-ups)
- E2E kanban hide/show-all flow tests
- UX decision when threshold is lowered while focus set exceeds the new threshold
- Focus mode in list/network views (kanban only for v1)

Closes #24

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
